### PR TITLE
멘티 일정 조회 기능에 인증 로직을 반영한다. 

### DIFF
--- a/src/main/java/cobook/buddywisdom/global/security/CustomUserDetails.java
+++ b/src/main/java/cobook/buddywisdom/global/security/CustomUserDetails.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 public class CustomUserDetails implements UserDetails, Serializable {
 
     private final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
-    private int id;
+    private Long id;
     private String email;
     private String password;
     private RoleType role;
@@ -32,7 +32,7 @@ public class CustomUserDetails implements UserDetails, Serializable {
         return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
     }
 
-    public int getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/cobook/buddywisdom/global/security/domain/vo/AuthMember.java
+++ b/src/main/java/cobook/buddywisdom/global/security/domain/vo/AuthMember.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AuthMember {
-    private int id;
+    private Long id;
     private String email;
     private String password;
     private String role;

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -4,12 +4,14 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import cobook.buddywisdom.global.security.CustomUserDetails;
 import cobook.buddywisdom.mentee.dto.MenteeMonthlyScheduleResponse;
 import cobook.buddywisdom.mentee.dto.MenteeScheduleFeedbackResponse;
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
@@ -26,16 +28,16 @@ public class MenteeController {
 		this.menteeScheduleService = menteeScheduleService;
 	}
 
-	// TODO : menteeId는 인증된 객체의 정보 활용 -> 테스트 코드도 변경
-	@GetMapping(value = "/schedule/{menteeId}")
-	public ResponseEntity<Optional<List<MenteeMonthlyScheduleResponse>>> getMenteeMonthlySchedule(@PathVariable Long menteeId,
+	@GetMapping(value = "/schedule")
+	public ResponseEntity<Optional<List<MenteeMonthlyScheduleResponse>>> getMenteeMonthlySchedule(@AuthenticationPrincipal CustomUserDetails member,
 																								@RequestBody @Valid MenteeMonthlyScheduleRequest request) {
-		return ResponseEntity.ok(Optional.ofNullable(menteeScheduleService.getMenteeMonthlySchedule(menteeId, request)));
+		return ResponseEntity.ok(Optional.ofNullable(menteeScheduleService.getMenteeMonthlySchedule(member.getId(), request)));
 	}
 
-	@GetMapping(value = "/schedule/feedback/{menteeId}/{scheduleId}")
-	public ResponseEntity<MenteeScheduleFeedbackResponse> getMenteeScheduleFeedback(@PathVariable Long menteeId, @PathVariable Long scheduleId) {
-		return ResponseEntity.ok(menteeScheduleService.getMenteeScheduleFeedback(menteeId, scheduleId));
+	@GetMapping(value = "/schedule/feedback/{scheduleId}")
+	public ResponseEntity<MenteeScheduleFeedbackResponse> getMenteeScheduleFeedback(@AuthenticationPrincipal CustomUserDetails member,
+																					@PathVariable Long scheduleId) {
+		return ResponseEntity.ok(menteeScheduleService.getMenteeScheduleFeedback(member.getId(), scheduleId));
 	}
 
 }

--- a/src/test/java/cobook/buddywisdom/auth/controller/AuthControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/auth/controller/AuthControllerTest.java
@@ -1,6 +1,6 @@
 //package cobook.buddywisdom.auth.controller;
 //
-//import cobook.buddywisdom.auth.WithMockCustomUser;
+//import cobook.buddywisdom.util.WithMockCustomUser;
 //import cobook.buddywisdom.auth.dto.LoginRequestDto;
 //import cobook.buddywisdom.auth.mapper.MemberMapper;
 //import cobook.buddywisdom.global.security.domain.vo.AuthMember;

--- a/src/test/java/cobook/buddywisdom/auth/service/AuthServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/auth/service/AuthServiceTest.java
@@ -1,6 +1,6 @@
 //package cobook.buddywisdom.auth.service;
 //
-//import cobook.buddywisdom.auth.WithMockCustomUser;
+//import cobook.buddywisdom.util.WithMockCustomUser;
 //import cobook.buddywisdom.auth.mapper.MemberMapper;
 //import cobook.buddywisdom.global.exception.ErrorMessage;
 //import cobook.buddywisdom.global.exception.NotFoundMemberException;

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -1,102 +1,100 @@
-//package cobook.buddywisdom.mentee.controller;
-//
-//
-//import java.time.LocalDate;
-//import java.time.LocalDateTime;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.BDDMockito;
-//import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.http.MediaType;
-//import org.springframework.test.web.servlet.MockMvc;
-//import org.springframework.test.web.servlet.ResultActions;
-//import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-//import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-//import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//
-//import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
-//import cobook.buddywisdom.mentee.service.MenteeScheduleService;
-//import jakarta.validation.constraints.Null;
-//
-//@AutoConfigureMybatis
-//@WebMvcTest(MenteeController.class)
-//public class MenteeControllerTest {
-//
-//	@MockBean
-//	private MenteeScheduleService menteeScheduleService;
-//
-//	@Autowired
-//	private MockMvc mockMvc;
-//
-//	@Autowired
-//	private ObjectMapper objectMapper;
-//
-//	@Nested
-//	@DisplayName("월별 스케줄 조회")
-//	class MonthlyScheduleTest {
-//		@Test
-//		@DisplayName("일정 정보가 모두 전달되면 메서드를 호출하고 200 OK를 반환한다.")
-//		void when_dateIsValid_expect_callMethodAndReturn200Ok() throws Exception {
-//			Long menteeId = 1L;
-//
-//			LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
-//			LocalDateTime startDateTime = LocalDateTime.parse(firstDayOfMonth + "T00:00:00");
-//			LocalDateTime endDateTime = LocalDateTime.parse(LocalDate.now().withDayOfMonth(firstDayOfMonth.lengthOfMonth()) + "T23:59:59");
-//
-//			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(startDateTime, endDateTime);
-//
-//			ResultActions response =
-//				mockMvc.perform(
-//					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/" + menteeId)
-//						.contentType(MediaType.APPLICATION_JSON)
-//						.content(objectMapper.writeValueAsBytes(request)))
-//				.andDo(MockMvcResultHandlers.print());
-//
-//			BDDMockito.verify(menteeScheduleService).getMenteeMonthlySchedule(BDDMockito.anyLong(), BDDMockito.any());
-//			response.andExpect(MockMvcResultMatchers.status().isOk());
-//		}
-//
-//		@Test
-//		@DisplayName("일정 정보가 null 값이라면 400 Bad Request가 반환된다.")
-//		void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail() throws Exception {
-//			Long menteeId = 1L;
-//
-//			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(null, null);
-//
-//			ResultActions response =
-//				mockMvc.perform(
-//					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/" + menteeId)
-//						.contentType(MediaType.APPLICATION_JSON)
-//						.content(objectMapper.writeValueAsBytes(request)))
-//				.andDo(MockMvcResultHandlers.print());
-//
-//			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName("스케줄 피드백 조회")
-//	class ScheduleFeedbackTest {
-//		@Test
-//		@DisplayName("유효한 스케줄 id가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
-//		void when_scheduleIdIsValid_expect_callMethodAndReturn200Ok() throws Exception {
-//			Long menteeId = 1L;
-//			Long scheduleId = 1L;
-//
-//			ResultActions response =
-//				mockMvc.perform(
-//					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/feedback/" + menteeId + "/" + scheduleId))
-//				.andDo(MockMvcResultHandlers.print());
-//
-//			BDDMockito.verify(menteeScheduleService).getMenteeScheduleFeedback(BDDMockito.anyLong(), BDDMockito.anyLong());
-//			response.andExpect(MockMvcResultMatchers.status().isOk());
-//		}
-//	}
-//}
+package cobook.buddywisdom.mentee.controller;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
+import cobook.buddywisdom.mentee.service.MenteeScheduleService;
+import cobook.buddywisdom.util.WithMockCustomUser;
+
+@AutoConfigureMybatis
+@WebMvcTest(MenteeController.class)
+public class MenteeControllerTest {
+
+	@MockBean
+	private MenteeScheduleService menteeScheduleService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Nested
+	@DisplayName("월별 스케줄 조회")
+	class MonthlyScheduleTest {
+		@Test
+		@WithMockCustomUser
+		@DisplayName("일정 정보가 모두 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_dateIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+			LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
+			LocalDateTime startDateTime = LocalDateTime.parse(firstDayOfMonth + "T00:00:00");
+			LocalDateTime endDateTime = LocalDateTime.parse(LocalDate.now().withDayOfMonth(firstDayOfMonth.lengthOfMonth()) + "T23:59:59");
+
+			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(startDateTime, endDateTime);
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.get("/api/v1/mentees/schedule")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsBytes(request)))
+				.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(menteeScheduleService).getMenteeMonthlySchedule(BDDMockito.anyLong(), BDDMockito.any());
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@Test
+		@WithMockCustomUser
+		@DisplayName("일정 정보가 null 값이라면 400 Bad Request가 반환된다.")
+		void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail() throws Exception {
+			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(null, null);
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.get("/api/v1/mentees/schedule")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsBytes(request)))
+				.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("스케줄 피드백 조회")
+	class ScheduleFeedbackTest {
+		@Test
+		@WithMockCustomUser
+		@DisplayName("유효한 스케줄 id가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_scheduleIdIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+			Long scheduleId = 1L;
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/feedback/" + scheduleId))
+				.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(menteeScheduleService).getMenteeScheduleFeedback(BDDMockito.anyLong(), BDDMockito.anyLong());
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+	}
+}

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -42,7 +42,7 @@ public class MenteeControllerTest {
 	@DisplayName("월별 스케줄 조회")
 	class MonthlyScheduleTest {
 		@Test
-		@WithMockCustomUser
+		@WithMockCustomUser(role = "MENTEE")
 		@DisplayName("일정 정보가 모두 전달되면 메서드를 호출하고 200 OK를 반환한다.")
 		void when_dateIsValid_expect_callMethodAndReturn200Ok() throws Exception {
 			LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
@@ -63,7 +63,7 @@ public class MenteeControllerTest {
 		}
 
 		@Test
-		@WithMockCustomUser
+		@WithMockCustomUser(role = "MENTEE")
 		@DisplayName("일정 정보가 null 값이라면 400 Bad Request가 반환된다.")
 		void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail() throws Exception {
 			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(null, null);
@@ -83,7 +83,7 @@ public class MenteeControllerTest {
 	@DisplayName("스케줄 피드백 조회")
 	class ScheduleFeedbackTest {
 		@Test
-		@WithMockCustomUser
+		@WithMockCustomUser(role = "MENTEE")
 		@DisplayName("유효한 스케줄 id가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
 		void when_scheduleIdIsValid_expect_callMethodAndReturn200Ok() throws Exception {
 			Long scheduleId = 1L;

--- a/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
@@ -1,118 +1,118 @@
-//package cobook.buddywisdom.mentee.service;
-//
-//
-//import java.time.LocalDate;
-//import java.time.LocalDateTime;
-//import java.util.List;
-//import java.util.Optional;
-//
-//import org.assertj.core.api.AssertionsForClassTypes;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.BDDMockito;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
-//import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
-//import cobook.buddywisdom.mentee.dto.MenteeMonthlyScheduleResponse;
-//import cobook.buddywisdom.mentee.dto.MenteeScheduleFeedbackResponse;
-//import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
-//import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
-//import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class MenteeServiceTest {
-//
-//	@Mock
-//	MenteeScheduleMapper menteeScheduleMapper;
-//
-//	@InjectMocks
-//	MenteeScheduleService menteeScheduleService;
-//
-//	@Nested
-//	@DisplayName("월별 스케줄 조회")
-//	class MonthlyScheduleTest {
-//		@Test
-//		@DisplayName("해당하는 스케줄 정보가 존재하면 월별 스케줄 정보를 반환한다.")
-//		void when_scheduleExistsWithInformation_expect_returnResponseList() {
-//			Long menteeId = 1L;
-//
-//			MenteeMonthlySchedule menteeMonthlySchedule = MenteeMonthlySchedule.of( 1L, false, LocalDateTime.now());
-//
-//			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
-//				.willReturn(menteeMonthlySchedule);
-//
-//			List<MenteeMonthlyScheduleResponse> expectedResponse =
-//				menteeScheduleService.getMenteeMonthlySchedule(menteeId, getMenteeMonthlyScheduleRequest());
-//
-//			Assertions.assertNotNull(expectedResponse);
-//			Assertions.assertEquals(1, expectedResponse.size());
-//		}
-//
-//		@Test
-//		@DisplayName("해당하는 스케줄 정보가 존재하지 않으면 빈 배열을 반환한다.")
-//		void when_scheduleDoesNotExistsWithInformation_expect_returnEmptyArray() {
-//			Long menteeId = 1L;
-//
-//			BDDMockito
-//				.given(menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
-//				.willReturn(null);
-//
-//			List<MenteeMonthlyScheduleResponse> expectedResponse =
-//				menteeScheduleService.getMenteeMonthlySchedule(menteeId, getMenteeMonthlyScheduleRequest());
-//
-//			Assertions.assertTrue(expectedResponse.isEmpty());
-//		}
-//
-//	}
-//
-//	@Nested
-//	@DisplayName("스케줄 피드백 조회")
-//	class ScheduleFeedbackTest {
-//		@Test
-//		@DisplayName("해당하는 스케줄 정보가 존재하면 스케줄 피드백 정보를 반환한다.")
-//		void when_scheduleExistsWithInformation_expect_returnResponse() {
-//			Long menteeId = 1L;
-//			Long scheduleId = 1L;
-//
-//			MenteeScheduleFeedback menteeScheduleFeedback =
-//				MenteeScheduleFeedback.of(1L, "코치 피드백", "멘티 피드백", LocalDateTime.now());
-//
-//			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
-//				.willReturn(Optional.of(menteeScheduleFeedback));
-//
-//			MenteeScheduleFeedbackResponse expectedResponse =
-//				menteeScheduleService.getMenteeScheduleFeedback(menteeId, scheduleId);
-//
-//			Assertions.assertNotNull(expectedResponse);
-//			Assertions.assertEquals(menteeScheduleFeedback.getId(), expectedResponse.id());
-//		}
-//
-//		@Test
-//		@DisplayName("해당하는 스케줄 정보가 존재하지 않으면 NotFoundMenteeScheduleException이 발생한다.")
-//		void when_scheduleDoesNotExists_expect_throwsNotFoundMenteeScheduleException() {
-//			Long menteeId = 1L;
-//			Long scheduleId = 1L;
-//
-//			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
-//				.willThrow(NotFoundMenteeScheduleException.class);
-//
-//			AssertionsForClassTypes.assertThatThrownBy(() ->
-//					menteeScheduleService.getMenteeScheduleFeedback(menteeId, scheduleId))
-//			.isInstanceOf(NotFoundMenteeScheduleException.class);
-//		}
-//	}
-//
-//	public static MenteeMonthlyScheduleRequest getMenteeMonthlyScheduleRequest() {
-//		LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
-//		LocalDateTime startDateTime = LocalDateTime.parse(firstDayOfMonth + "T00:00:00");
-//		LocalDateTime endDateTime = LocalDateTime.parse(LocalDate.now().withDayOfMonth(firstDayOfMonth.lengthOfMonth()) + "T23:59:59");
-//
-//		return new MenteeMonthlyScheduleRequest(startDateTime, endDateTime);
-//	}
-//}
+package cobook.buddywisdom.mentee.service;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
+import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
+import cobook.buddywisdom.mentee.dto.MenteeMonthlyScheduleResponse;
+import cobook.buddywisdom.mentee.dto.MenteeScheduleFeedbackResponse;
+import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
+import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
+import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class MenteeServiceTest {
+
+	@Mock
+	MenteeScheduleMapper menteeScheduleMapper;
+
+	@InjectMocks
+	MenteeScheduleService menteeScheduleService;
+
+	@Nested
+	@DisplayName("월별 스케줄 조회")
+	class MonthlyScheduleTest {
+		@Test
+		@DisplayName("해당하는 스케줄 정보가 존재하면 월별 스케줄 정보를 반환한다.")
+		void when_scheduleExistsWithInformation_expect_returnResponseList() {
+			Long menteeId = 1L;
+
+			MenteeMonthlySchedule menteeMonthlySchedule = MenteeMonthlySchedule.of( 1L, false, LocalDateTime.now());
+
+			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
+				.willReturn(menteeMonthlySchedule);
+
+			List<MenteeMonthlyScheduleResponse> expectedResponse =
+				menteeScheduleService.getMenteeMonthlySchedule(menteeId, getMenteeMonthlyScheduleRequest());
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertEquals(1, expectedResponse.size());
+		}
+
+		@Test
+		@DisplayName("해당하는 스케줄 정보가 존재하지 않으면 빈 배열을 반환한다.")
+		void when_scheduleDoesNotExistsWithInformation_expect_returnEmptyArray() {
+			Long menteeId = 1L;
+
+			BDDMockito
+				.given(menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
+				.willReturn(null);
+
+			List<MenteeMonthlyScheduleResponse> expectedResponse =
+				menteeScheduleService.getMenteeMonthlySchedule(menteeId, getMenteeMonthlyScheduleRequest());
+
+			Assertions.assertTrue(expectedResponse.isEmpty());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("스케줄 피드백 조회")
+	class ScheduleFeedbackTest {
+		@Test
+		@DisplayName("해당하는 스케줄 정보가 존재하면 스케줄 피드백 정보를 반환한다.")
+		void when_scheduleExistsWithInformation_expect_returnResponse() {
+			Long menteeId = 1L;
+			Long scheduleId = 1L;
+
+			MenteeScheduleFeedback menteeScheduleFeedback =
+				MenteeScheduleFeedback.of(1L, "코치 피드백", "멘티 피드백", LocalDateTime.now());
+
+			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
+				.willReturn(Optional.of(menteeScheduleFeedback));
+
+			MenteeScheduleFeedbackResponse expectedResponse =
+				menteeScheduleService.getMenteeScheduleFeedback(menteeId, scheduleId);
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertEquals(menteeScheduleFeedback.getId(), expectedResponse.id());
+		}
+
+		@Test
+		@DisplayName("해당하는 스케줄 정보가 존재하지 않으면 NotFoundMenteeScheduleException이 발생한다.")
+		void when_scheduleDoesNotExists_expect_throwsNotFoundMenteeScheduleException() {
+			Long menteeId = 1L;
+			Long scheduleId = 1L;
+
+			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
+				.willThrow(NotFoundMenteeScheduleException.class);
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					menteeScheduleService.getMenteeScheduleFeedback(menteeId, scheduleId))
+			.isInstanceOf(NotFoundMenteeScheduleException.class);
+		}
+	}
+
+	public static MenteeMonthlyScheduleRequest getMenteeMonthlyScheduleRequest() {
+		LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
+		LocalDateTime startDateTime = LocalDateTime.parse(firstDayOfMonth + "T00:00:00");
+		LocalDateTime endDateTime = LocalDateTime.parse(LocalDate.now().withDayOfMonth(firstDayOfMonth.lengthOfMonth()) + "T23:59:59");
+
+		return new MenteeMonthlyScheduleRequest(startDateTime, endDateTime);
+	}
+}

--- a/src/test/java/cobook/buddywisdom/util/WithMockCustomUser.java
+++ b/src/test/java/cobook/buddywisdom/util/WithMockCustomUser.java
@@ -1,4 +1,4 @@
-package cobook.buddywisdom.auth;
+package cobook.buddywisdom.util;
 
 import org.springframework.security.test.context.support.WithSecurityContext;
 
@@ -10,7 +10,7 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
 public @interface WithMockCustomUser {
-    int id() default 1;
+    long id() default 1L;
     String username() default "admin@mock.test";
     String password() default "password";
     String role() default "ADMIN";

--- a/src/test/java/cobook/buddywisdom/util/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/cobook/buddywisdom/util/WithMockCustomUserSecurityContextFactory.java
@@ -1,4 +1,4 @@
-package cobook.buddywisdom.auth;
+package cobook.buddywisdom.util;
 
 import cobook.buddywisdom.global.security.domain.vo.RoleType;
 import cobook.buddywisdom.global.security.CustomUserDetails;


### PR DESCRIPTION
### 작업 내용
- 조회 API에 파라미터로 전달받던 menteeId를 인증 객체 정보로 활용하도록 변경한다.
- 기존 테스트 코드에 인증 객체 어노테이션을 적용한다.