### PR TITLE
[#10] 멘티 일정 신청 기능을 구현한다.

### DIFF
--- a/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
+++ b/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
@@ -1,0 +1,13 @@
+package cobook.buddywisdom.coach.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class CoachSchedule {
+	private Long id;
+	private Long coachId;
+	private LocalDateTime possibleDateTime;
+
+}

--- a/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
+++ b/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
@@ -14,8 +14,9 @@ public class CoachSchedule {
 	private LocalDateTime possibleDateTime;
 	private boolean matchYn;
 
-	public static CoachSchedule of(Long coachId, LocalDateTime possibleDateTime, boolean matchYn) {
+	public static CoachSchedule of(Long id, Long coachId, LocalDateTime possibleDateTime, boolean matchYn) {
 		CoachSchedule coachSchedule = new CoachSchedule();
+		coachSchedule.id = id;
 		coachSchedule.coachId = coachId;
 		coachSchedule.possibleDateTime = possibleDateTime;
 		coachSchedule.matchYn = matchYn;

--- a/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
+++ b/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
@@ -2,12 +2,24 @@ package cobook.buddywisdom.coach.domain;
 
 import java.time.LocalDateTime;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CoachSchedule {
 	private Long id;
 	private Long coachId;
 	private LocalDateTime possibleDateTime;
 	private boolean matchYn;
+
+	public static CoachSchedule of(Long coachId, LocalDateTime possibleDateTime, boolean matchYn) {
+		CoachSchedule coachSchedule = new CoachSchedule();
+		coachSchedule.coachId = coachId;
+		coachSchedule.possibleDateTime = possibleDateTime;
+		coachSchedule.matchYn = matchYn;
+		return coachSchedule;
+
+	}
 }

--- a/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
+++ b/src/main/java/cobook/buddywisdom/coach/domain/CoachSchedule.java
@@ -9,5 +9,5 @@ public class CoachSchedule {
 	private Long id;
 	private Long coachId;
 	private LocalDateTime possibleDateTime;
-
+	private boolean matchYn;
 }

--- a/src/main/java/cobook/buddywisdom/coach/exception/NotFoundCoachScheduleException.java
+++ b/src/main/java/cobook/buddywisdom/coach/exception/NotFoundCoachScheduleException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.coach.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class NotFoundCoachScheduleException extends RuntimeException {
+	public NotFoundCoachScheduleException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
@@ -1,5 +1,6 @@
 package cobook.buddywisdom.coach.mapper;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -9,4 +10,6 @@ import cobook.buddywisdom.coach.domain.CoachSchedule;
 @Mapper
 public interface CoachScheduleMapper {
 	Optional<CoachSchedule> findById(Long id);
+	List<CoachSchedule> findAllByCoachId(Long coachId);
+	void setMatchYn(Long id, boolean matchYn);
 }

--- a/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
@@ -1,5 +1,7 @@
 package cobook.buddywisdom.coach.mapper;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +12,6 @@ import cobook.buddywisdom.coach.domain.CoachSchedule;
 @Mapper
 public interface CoachScheduleMapper {
 	Optional<CoachSchedule> findByIdAndMatchYn(Long id, boolean matchYn);
-	List<CoachSchedule> findAllByCoachId(Long coachId);
+	List<CoachSchedule> findAllByCoachIdAndPossibleDateTime(Long coachId, LocalDate startDateTime, LocalDate endDateTime);
 	void setMatchYn(Long id, boolean matchYn);
 }

--- a/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
@@ -9,7 +9,7 @@ import cobook.buddywisdom.coach.domain.CoachSchedule;
 
 @Mapper
 public interface CoachScheduleMapper {
-	Optional<CoachSchedule> findById(Long id);
+	Optional<CoachSchedule> findByIdAndMatchYn(Long id, boolean matchYn);
 	List<CoachSchedule> findAllByCoachId(Long coachId);
 	void setMatchYn(Long id, boolean matchYn);
 }

--- a/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
@@ -1,0 +1,12 @@
+package cobook.buddywisdom.coach.mapper;
+
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+
+@Mapper
+public interface CoachScheduleMapper {
+	Optional<CoachSchedule> findById(Long id);
+}

--- a/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/coach/mapper/CoachScheduleMapper.java
@@ -11,7 +11,7 @@ import cobook.buddywisdom.coach.domain.CoachSchedule;
 
 @Mapper
 public interface CoachScheduleMapper {
-	Optional<CoachSchedule> findByIdAndMatchYn(Long id, boolean matchYn);
-	List<CoachSchedule> findAllByCoachIdAndPossibleDateTime(Long coachId, LocalDate startDateTime, LocalDate endDateTime);
-	void setMatchYn(Long id, boolean matchYn);
+	Optional<CoachSchedule> findByIdAndMatchYn(long id, boolean matchYn);
+	List<CoachSchedule> findAllByCoachIdAndPossibleDateTime(long coachId, LocalDate startDateTime, LocalDate endDateTime);
+	void setMatchYn(long id, boolean matchYn);
 }

--- a/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
@@ -22,16 +22,16 @@ public class CoachScheduleService {
 		this.coachScheduleMapper = coachScheduleMapper;
 	}
 
-	public CoachSchedule getCoachSchedule(Long id, boolean matchYn) {
+	public CoachSchedule getCoachSchedule(long id, boolean matchYn) {
 		return coachScheduleMapper.findByIdAndMatchYn(id, matchYn)
 			.orElseThrow(() -> new NotFoundCoachScheduleException(ErrorMessage.NOT_FOUND_COACH_SCHEDULE));
 	}
 
-	public List<CoachSchedule> getAllCoachingSchedule(Long coachId, LocalDate startDateTime, LocalDate endDateTime) {
+	public List<CoachSchedule> getAllCoachingSchedule(long coachId, LocalDate startDateTime, LocalDate endDateTime) {
 		return coachScheduleMapper.findAllByCoachIdAndPossibleDateTime(coachId, startDateTime, endDateTime);
 	}
 
-	public void updateMatchYn(Long id, boolean matchYn) {
+	public void updateMatchYn(long id, boolean matchYn) {
 		coachScheduleMapper.setMatchYn(id, matchYn);
 	}
 }

--- a/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
@@ -1,0 +1,26 @@
+package cobook.buddywisdom.coach.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+import cobook.buddywisdom.coach.mapper.CoachScheduleMapper;
+import cobook.buddywisdom.global.exception.ErrorMessage;
+import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
+
+@Service
+@Transactional(readOnly = true)
+public class CoachScheduleService {
+
+	private final CoachScheduleMapper coachScheduleMapper;
+
+	public CoachScheduleService(CoachScheduleMapper coachScheduleMapper) {
+		this.coachScheduleMapper = coachScheduleMapper;
+	}
+
+	public CoachSchedule getCoachSchedule(Long id) {
+		return coachScheduleMapper.findById(id)
+			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_COACH_SCHEDULE));
+	}
+
+}

--- a/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
@@ -20,8 +20,8 @@ public class CoachScheduleService {
 		this.coachScheduleMapper = coachScheduleMapper;
 	}
 
-	public CoachSchedule getCoachSchedule(Long id) {
-		return coachScheduleMapper.findById(id)
+	public CoachSchedule getCoachSchedule(Long id, boolean matchYn) {
+		return coachScheduleMapper.findByIdAndMatchYn(id, matchYn)
 			.orElseThrow(() -> new NotFoundCoachScheduleException(ErrorMessage.NOT_FOUND_COACH_SCHEDULE));
 	}
 

--- a/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
@@ -1,5 +1,7 @@
 package cobook.buddywisdom.coach.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -25,8 +27,8 @@ public class CoachScheduleService {
 			.orElseThrow(() -> new NotFoundCoachScheduleException(ErrorMessage.NOT_FOUND_COACH_SCHEDULE));
 	}
 
-	public List<CoachSchedule> getAllCoachingSchedule(Long coachId) {
-		return coachScheduleMapper.findAllByCoachId(coachId);
+	public List<CoachSchedule> getAllCoachingSchedule(Long coachId, LocalDate startDateTime, LocalDate endDateTime) {
+		return coachScheduleMapper.findAllByCoachIdAndPossibleDateTime(coachId, startDateTime, endDateTime);
 	}
 
 	public void updateMatchYn(Long id, boolean matchYn) {

--- a/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/coach/service/CoachScheduleService.java
@@ -1,12 +1,14 @@
 package cobook.buddywisdom.coach.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cobook.buddywisdom.coach.domain.CoachSchedule;
+import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
 import cobook.buddywisdom.coach.mapper.CoachScheduleMapper;
 import cobook.buddywisdom.global.exception.ErrorMessage;
-import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,7 +22,14 @@ public class CoachScheduleService {
 
 	public CoachSchedule getCoachSchedule(Long id) {
 		return coachScheduleMapper.findById(id)
-			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_COACH_SCHEDULE));
+			.orElseThrow(() -> new NotFoundCoachScheduleException(ErrorMessage.NOT_FOUND_COACH_SCHEDULE));
 	}
 
+	public List<CoachSchedule> getAllCoachingSchedule(Long coachId) {
+		return coachScheduleMapper.findAllByCoachId(coachId);
+	}
+
+	public void updateMatchYn(Long id, boolean matchYn) {
+		coachScheduleMapper.setMatchYn(id, matchYn);
+	}
 }

--- a/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
@@ -41,4 +41,10 @@ public class ApiExceptionHandler {
 		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE);
 	}
 
+	@ExceptionHandler(DuplicatedMenteeScheduleException.class)
+	public ResponseEntity<ErrorResponse> handleDuplicatedMenteeScheduleException(DuplicatedMenteeScheduleException exception) {
+		log.error("DuplicatedMenteeScheduleException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.DUPLICATED_MENTEE_SCHEDULE);
+	}
+
 }

--- a/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
@@ -9,18 +9,14 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
+import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
 public class ApiExceptionHandler {
-
-	@ExceptionHandler(NotFoundMenteeScheduleException.class)
-	public ResponseEntity<ErrorResponse> handleNotFoundMenteeScheduleException(NotFoundMenteeScheduleException exception) {
-		log.error("NotFoundMenteeScheduleException : ", exception);
-		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE);
-	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException exception) {
@@ -32,4 +28,17 @@ public class ApiExceptionHandler {
 
 		return ResponseEntity.badRequest().body(errors);
 	}
+
+	@ExceptionHandler(NotFoundCoachScheduleException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundCoachScheduleException(NotFoundCoachScheduleException exception) {
+		log.error("NotFoundCoachScheduleException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_COACH_SCHEDULE);
+	}
+
+	@ExceptionHandler(NotFoundMenteeScheduleException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundMenteeScheduleException(NotFoundMenteeScheduleException exception) {
+		log.error("NotFoundMenteeScheduleException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE);
+	}
+
 }

--- a/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
 import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
+import cobook.buddywisdom.relationship.exception.NotFoundRelationshipException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -47,4 +48,9 @@ public class ApiExceptionHandler {
 		return ErrorResponse.toResponseEntity(ErrorMessage.DUPLICATED_MENTEE_SCHEDULE);
 	}
 
+	@ExceptionHandler(NotFoundRelationshipException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundRelationshipException(NotFoundRelationshipException exception) {
+		log.error("NotFoundRelationshipException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_COACHING_RELATIONSHIP);
+	}
 }

--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -16,7 +16,7 @@ public enum ErrorMessage {
 	DUPLICATED_MENTEE_SCHEDULE(HttpStatus.BAD_REQUEST, "이미 해당 코칭 일정으로 등록된 스케줄이 존재합니다."),
 
 	// COACH
-	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 코치 스케줄이 존재하지 않습니다."),
+	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "이미 신청이 마감되었거나 존재하지 않는 스케줄입니다."),
 
 	// RELATIONSHIP
 	NOT_FOUND_COACHING_RELATIONSHIP(HttpStatus.NOT_FOUND, "매칭된 코칭 팀이 존재하지 않습니다.")

--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
 
 	// MENTEE
 	NOT_FOUND_MENTEE_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 멘티 스케줄이 존재하지 않습니다."),
+	DUPLICATED_MENTEE_SCHEDULE(HttpStatus.BAD_REQUEST, "이미 해당 코칭 일정으로 등록된 스케줄이 존재합니다."),
 
 	// COACH
 	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 코치 스케줄이 존재하지 않습니다.")

--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -7,9 +7,15 @@ import lombok.Getter;
 @Getter
 public enum ErrorMessage {
 
-	NOT_FOUND_MENTEE_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 멘티 스케줄이 존재하지 않습니다."),
+	// MEMBER
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "등록된 회원이 존재하지 않습니다."),
 	INVALID_CREDENTIALS_EXCEPTION(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
+
+	// MENTEE
+	NOT_FOUND_MENTEE_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 멘티 스케줄이 존재하지 않습니다."),
+
+	// COACH
+	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 코치 스케줄이 존재하지 않습니다.")
 
 	;
 

--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -16,7 +16,10 @@ public enum ErrorMessage {
 	DUPLICATED_MENTEE_SCHEDULE(HttpStatus.BAD_REQUEST, "이미 해당 코칭 일정으로 등록된 스케줄이 존재합니다."),
 
 	// COACH
-	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 코치 스케줄이 존재하지 않습니다.")
+	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 코치 스케줄이 존재하지 않습니다."),
+
+	// RELATIONSHIP
+	NOT_FOUND_COACHING_RELATIONSHIP(HttpStatus.NOT_FOUND, "매칭된 코칭 팀이 존재하지 않습니다.")
 
 	;
 

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -38,7 +38,7 @@ public class MenteeController {
 
 	@GetMapping(value = "/schedule/{scheduleId}")
 	public ResponseEntity<MenteeScheduleFeedbackResponseDto> getMenteeScheduleFeedback(@AuthenticationPrincipal CustomUserDetails member,
-																					@PathVariable Long scheduleId) {
+																					@PathVariable final long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.getMenteeScheduleFeedback(member.getId(), scheduleId));
 	}
 
@@ -49,7 +49,7 @@ public class MenteeController {
 
 	@PostMapping(value = "/schedule/{scheduleId}")
 	public ResponseEntity<MenteeScheduleResponseDto> createMenteeSchedule(@AuthenticationPrincipal CustomUserDetails member,
-																			@PathVariable Long scheduleId) {
+																			@PathVariable final long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.saveMenteeSchedule(member.getId(), scheduleId));
 	}
 }

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -1,7 +1,6 @@
 package cobook.buddywisdom.mentee.controller;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,9 +31,9 @@ public class MenteeController {
 	}
 
 	@GetMapping(value = "/schedule")
-	public ResponseEntity<Optional<List<MenteeMonthlyScheduleResponseDto>>> getMenteeMonthlySchedule(@AuthenticationPrincipal CustomUserDetails member,
+	public ResponseEntity<List<MenteeMonthlyScheduleResponseDto>> getMenteeMonthlySchedule(@AuthenticationPrincipal CustomUserDetails member,
 																								@RequestBody @Valid MenteeMonthlyScheduleRequestDto request) {
-		return ResponseEntity.ok(Optional.ofNullable(menteeScheduleService.getMenteeMonthlySchedule(member.getId(), request)));
+		return ResponseEntity.ok(menteeScheduleService.getMenteeMonthlySchedule(member.getId(), request));
 	}
 
 	@GetMapping(value = "/schedule/feedback/{scheduleId}")
@@ -44,8 +43,8 @@ public class MenteeController {
 	}
 
 	@GetMapping(value = "/schedule/create")
-	public ResponseEntity<Optional<List<MyCoachScheduleResponseDto>>> getMyCoachSchedule(@AuthenticationPrincipal CustomUserDetails member) {
-		return ResponseEntity.ok(Optional.ofNullable(menteeScheduleService.getMyCoachSchedule(member.getId())));
+	public ResponseEntity<List<MyCoachScheduleResponseDto>> getMyCoachSchedule(@AuthenticationPrincipal CustomUserDetails member) {
+		return ResponseEntity.ok(menteeScheduleService.getMyCoachSchedule(member.getId()));
 	}
 
 	@PostMapping(value = "/schedule/create/{scheduleId}")

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -17,6 +17,7 @@ import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleResponseDto;
+import cobook.buddywisdom.mentee.dto.response.MyCoachScheduleResponseDto;
 import cobook.buddywisdom.mentee.service.MenteeScheduleService;
 import jakarta.validation.Valid;
 
@@ -42,7 +43,12 @@ public class MenteeController {
 		return ResponseEntity.ok(menteeScheduleService.getMenteeScheduleFeedback(member.getId(), scheduleId));
 	}
 
-	@PostMapping(value = "/schedule/{scheduleId}")
+	@GetMapping(value = "/schedule/create")
+	public ResponseEntity<Optional<List<MyCoachScheduleResponseDto>>> getMyCoachSchedule(@AuthenticationPrincipal CustomUserDetails member) {
+		return ResponseEntity.ok(Optional.ofNullable(menteeScheduleService.getMyCoachSchedule(member.getId())));
+	}
+
+	@PostMapping(value = "/schedule/create/{scheduleId}")
 	public ResponseEntity<MenteeScheduleResponseDto> createMenteeSchedule(@AuthenticationPrincipal CustomUserDetails member,
 																			@PathVariable Long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.saveMenteeSchedule(member.getId(), scheduleId));

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -7,14 +7,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import cobook.buddywisdom.global.security.CustomUserDetails;
-import cobook.buddywisdom.mentee.dto.MenteeMonthlyScheduleResponse;
-import cobook.buddywisdom.mentee.dto.MenteeScheduleFeedbackResponse;
-import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
+import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
+import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
+import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
+import cobook.buddywisdom.mentee.dto.response.MenteeScheduleResponseDto;
 import cobook.buddywisdom.mentee.service.MenteeScheduleService;
 import jakarta.validation.Valid;
 
@@ -29,15 +31,20 @@ public class MenteeController {
 	}
 
 	@GetMapping(value = "/schedule")
-	public ResponseEntity<Optional<List<MenteeMonthlyScheduleResponse>>> getMenteeMonthlySchedule(@AuthenticationPrincipal CustomUserDetails member,
-																								@RequestBody @Valid MenteeMonthlyScheduleRequest request) {
+	public ResponseEntity<Optional<List<MenteeMonthlyScheduleResponseDto>>> getMenteeMonthlySchedule(@AuthenticationPrincipal CustomUserDetails member,
+																								@RequestBody @Valid MenteeMonthlyScheduleRequestDto request) {
 		return ResponseEntity.ok(Optional.ofNullable(menteeScheduleService.getMenteeMonthlySchedule(member.getId(), request)));
 	}
 
 	@GetMapping(value = "/schedule/feedback/{scheduleId}")
-	public ResponseEntity<MenteeScheduleFeedbackResponse> getMenteeScheduleFeedback(@AuthenticationPrincipal CustomUserDetails member,
+	public ResponseEntity<MenteeScheduleFeedbackResponseDto> getMenteeScheduleFeedback(@AuthenticationPrincipal CustomUserDetails member,
 																					@PathVariable Long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.getMenteeScheduleFeedback(member.getId(), scheduleId));
 	}
 
+	@PostMapping(value = "/schedule/{scheduleId}")
+	public ResponseEntity<MenteeScheduleResponseDto> createMenteeSchedule(@AuthenticationPrincipal CustomUserDetails member,
+																			@PathVariable Long scheduleId) {
+		return ResponseEntity.ok(menteeScheduleService.saveMenteeSchedule(member.getId(), scheduleId));
+	}
 }

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -30,24 +30,24 @@ public class MenteeController {
 		this.menteeScheduleService = menteeScheduleService;
 	}
 
-	@GetMapping(value = "/schedule")
+	@GetMapping(value = "/schedule/monthly")
 	public ResponseEntity<List<MenteeMonthlyScheduleResponseDto>> getMenteeMonthlySchedule(@AuthenticationPrincipal CustomUserDetails member,
 																								@RequestBody @Valid MenteeMonthlyScheduleRequestDto request) {
 		return ResponseEntity.ok(menteeScheduleService.getMenteeMonthlySchedule(member.getId(), request));
 	}
 
-	@GetMapping(value = "/schedule/feedback/{scheduleId}")
+	@GetMapping(value = "/schedule/{scheduleId}")
 	public ResponseEntity<MenteeScheduleFeedbackResponseDto> getMenteeScheduleFeedback(@AuthenticationPrincipal CustomUserDetails member,
 																					@PathVariable Long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.getMenteeScheduleFeedback(member.getId(), scheduleId));
 	}
 
-	@GetMapping(value = "/schedule/create")
+	@GetMapping(value = "/schedule")
 	public ResponseEntity<List<MyCoachScheduleResponseDto>> getMyCoachSchedule(@AuthenticationPrincipal CustomUserDetails member) {
 		return ResponseEntity.ok(menteeScheduleService.getMyCoachSchedule(member.getId()));
 	}
 
-	@PostMapping(value = "/schedule/create/{scheduleId}")
+	@PostMapping(value = "/schedule/{scheduleId}")
 	public ResponseEntity<MenteeScheduleResponseDto> createMenteeSchedule(@AuthenticationPrincipal CustomUserDetails member,
 																			@PathVariable Long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.saveMenteeSchedule(member.getId(), scheduleId));

--- a/src/main/java/cobook/buddywisdom/mentee/domain/MenteeMonthlySchedule.java
+++ b/src/main/java/cobook/buddywisdom/mentee/domain/MenteeMonthlySchedule.java
@@ -9,15 +9,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MenteeMonthlySchedule {
-	private Long id;
 	private Long coachingScheduleId;
-	private boolean cancelYn;
 	private LocalDateTime possibleDateTime;
 
-	public static MenteeMonthlySchedule of(Long coachingScheduleId, boolean cancelYn, LocalDateTime possibleDateTime) {
+	public static MenteeMonthlySchedule of(Long coachingScheduleId, LocalDateTime possibleDateTime) {
 		MenteeMonthlySchedule menteeMonthlySchedule = new MenteeMonthlySchedule();
 		menteeMonthlySchedule.coachingScheduleId = coachingScheduleId;
-		menteeMonthlySchedule.cancelYn = cancelYn;
 		menteeMonthlySchedule.possibleDateTime = possibleDateTime;
 		return menteeMonthlySchedule;
 	}

--- a/src/main/java/cobook/buddywisdom/mentee/domain/MenteeSchedule.java
+++ b/src/main/java/cobook/buddywisdom/mentee/domain/MenteeSchedule.java
@@ -7,10 +7,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MenteeSchedule {
-	private Long id;
 	private Long coachingScheduleId;
 	private Long menteeId;
-	private boolean cancelYn;
 
 	public static MenteeSchedule of(Long coachingScheduleId, Long menteeId) {
 		MenteeSchedule menteeSchedule = new MenteeSchedule();

--- a/src/main/java/cobook/buddywisdom/mentee/domain/MenteeSchedule.java
+++ b/src/main/java/cobook/buddywisdom/mentee/domain/MenteeSchedule.java
@@ -1,0 +1,21 @@
+package cobook.buddywisdom.mentee.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenteeSchedule {
+	private Long id;
+	private Long coachingScheduleId;
+	private Long menteeId;
+	private boolean cancelYn;
+
+	public static MenteeSchedule of(Long coachingScheduleId, Long menteeId) {
+		MenteeSchedule menteeSchedule = new MenteeSchedule();
+		menteeSchedule.coachingScheduleId = coachingScheduleId;
+		menteeSchedule.menteeId = menteeId;
+		return menteeSchedule;
+	}
+}

--- a/src/main/java/cobook/buddywisdom/mentee/domain/MenteeScheduleFeedback.java
+++ b/src/main/java/cobook/buddywisdom/mentee/domain/MenteeScheduleFeedback.java
@@ -9,14 +9,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MenteeScheduleFeedback {
-	private Long id;
+	private Long coachingScheduleId;
 	private Long feedbackId;
 	private String coachFeedback;
 	private String menteeFeedback;
 	private LocalDateTime possibleDateTime;
 
-	public static MenteeScheduleFeedback of(Long feedbackId, String coachFeedback, String menteeFeedback, LocalDateTime possibleDateTime) {
+	public static MenteeScheduleFeedback of(Long coachingScheduleId, Long feedbackId, String coachFeedback, String menteeFeedback, LocalDateTime possibleDateTime) {
 		MenteeScheduleFeedback menteeScheduleFeedback = new MenteeScheduleFeedback();
+		menteeScheduleFeedback.coachingScheduleId = coachingScheduleId;
 		menteeScheduleFeedback.feedbackId = feedbackId;
 		menteeScheduleFeedback.coachFeedback = coachFeedback;
 		menteeScheduleFeedback.menteeFeedback = menteeFeedback;

--- a/src/main/java/cobook/buddywisdom/mentee/dto/request/MenteeMonthlyScheduleRequestDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/request/MenteeMonthlyScheduleRequestDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotNull;
 
-public record MenteeMonthlyScheduleRequest (
+public record MenteeMonthlyScheduleRequestDto(
 	@NotNull(message = "startDateTime 값이 필요합니다.")
 	LocalDateTime startDateTime,
 	@NotNull(message = "endDateTime 값이 필요합니다.")

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeMonthlyScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeMonthlyScheduleResponseDto.java
@@ -5,16 +5,12 @@ import java.time.LocalDateTime;
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
 
 public record MenteeMonthlyScheduleResponseDto(
-	Long id,
 	Long coachingScheduleId,
-	boolean cancelYn,
 	LocalDateTime possibleDateTime
 ) {
 	public static MenteeMonthlyScheduleResponseDto from(MenteeMonthlySchedule menteeMonthlySchedule) {
 		return new MenteeMonthlyScheduleResponseDto(
-			menteeMonthlySchedule.getId(),
 			menteeMonthlySchedule.getCoachingScheduleId(),
-			menteeMonthlySchedule.isCancelYn(),
 			menteeMonthlySchedule.getPossibleDateTime()
 		);
 	}

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeMonthlyScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeMonthlyScheduleResponseDto.java
@@ -1,17 +1,17 @@
-package cobook.buddywisdom.mentee.dto;
+package cobook.buddywisdom.mentee.dto.response;
 
 import java.time.LocalDateTime;
 
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
 
-public record MenteeMonthlyScheduleResponse(
+public record MenteeMonthlyScheduleResponseDto(
 	Long id,
 	Long coachingScheduleId,
 	boolean cancelYn,
 	LocalDateTime possibleDateTime
 ) {
-	public static MenteeMonthlyScheduleResponse from(MenteeMonthlySchedule menteeMonthlySchedule) {
-		return new MenteeMonthlyScheduleResponse(
+	public static MenteeMonthlyScheduleResponseDto from(MenteeMonthlySchedule menteeMonthlySchedule) {
+		return new MenteeMonthlyScheduleResponseDto(
 			menteeMonthlySchedule.getId(),
 			menteeMonthlySchedule.getCoachingScheduleId(),
 			menteeMonthlySchedule.isCancelYn(),

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeMonthlyScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeMonthlyScheduleResponseDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
 
 public record MenteeMonthlyScheduleResponseDto(
-	Long coachingScheduleId,
+	long coachingScheduleId,
 	LocalDateTime possibleDateTime
 ) {
 	public static MenteeMonthlyScheduleResponseDto from(MenteeMonthlySchedule menteeMonthlySchedule) {

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleFeedbackResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleFeedbackResponseDto.java
@@ -6,10 +6,10 @@ import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 import jakarta.annotation.Nullable;
 
 public record MenteeScheduleFeedbackResponseDto(
-	Long coachingScheduleId,
+	long coachingScheduleId,
 	LocalDateTime possibleDateTime,
 	@Nullable
-	Long feedbackId,
+	long feedbackId,
 	@Nullable
 	String menteeFeedBack,
 	@Nullable

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleFeedbackResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleFeedbackResponseDto.java
@@ -1,11 +1,11 @@
-package cobook.buddywisdom.mentee.dto;
+package cobook.buddywisdom.mentee.dto.response;
 
 import java.time.LocalDateTime;
 
 import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 import jakarta.annotation.Nullable;
 
-public record MenteeScheduleFeedbackResponse(
+public record MenteeScheduleFeedbackResponseDto(
 	Long id,
 	LocalDateTime possibleDateTime,
 	@Nullable
@@ -15,8 +15,8 @@ public record MenteeScheduleFeedbackResponse(
 	@Nullable
 	String coachFeedback
 ){
-	public static MenteeScheduleFeedbackResponse from(MenteeScheduleFeedback menteeScheduleFeedback) {
-		return new MenteeScheduleFeedbackResponse(
+	public static MenteeScheduleFeedbackResponseDto from(MenteeScheduleFeedback menteeScheduleFeedback) {
+		return new MenteeScheduleFeedbackResponseDto(
 			menteeScheduleFeedback.getId(),
 			menteeScheduleFeedback.getPossibleDateTime(),
 			menteeScheduleFeedback.getFeedbackId(),

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleFeedbackResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleFeedbackResponseDto.java
@@ -6,7 +6,7 @@ import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 import jakarta.annotation.Nullable;
 
 public record MenteeScheduleFeedbackResponseDto(
-	Long id,
+	Long coachingScheduleId,
 	LocalDateTime possibleDateTime,
 	@Nullable
 	Long feedbackId,
@@ -17,7 +17,7 @@ public record MenteeScheduleFeedbackResponseDto(
 ){
 	public static MenteeScheduleFeedbackResponseDto from(MenteeScheduleFeedback menteeScheduleFeedback) {
 		return new MenteeScheduleFeedbackResponseDto(
-			menteeScheduleFeedback.getId(),
+			menteeScheduleFeedback.getCoachingScheduleId(),
 			menteeScheduleFeedback.getPossibleDateTime(),
 			menteeScheduleFeedback.getFeedbackId(),
 			menteeScheduleFeedback.getMenteeFeedback(),

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleResponseDto.java
@@ -3,17 +3,13 @@ package cobook.buddywisdom.mentee.dto.response;
 import cobook.buddywisdom.mentee.domain.MenteeSchedule;
 
 public record MenteeScheduleResponseDto (
-	Long id,
 	Long coachingScheduleId,
-	Long menteeId,
-	boolean cancelYn
+	Long menteeId
 ) {
 	public static MenteeScheduleResponseDto from(MenteeSchedule menteeSchedule) {
 		return new MenteeScheduleResponseDto(
-			menteeSchedule.getId(),
 			menteeSchedule.getCoachingScheduleId(),
-			menteeSchedule.getMenteeId(),
-			menteeSchedule.isCancelYn()
+			menteeSchedule.getMenteeId()
 		);
 	}
 }

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleResponseDto.java
@@ -1,0 +1,19 @@
+package cobook.buddywisdom.mentee.dto.response;
+
+import cobook.buddywisdom.mentee.domain.MenteeSchedule;
+
+public record MenteeScheduleResponseDto (
+	Long id,
+	Long coachingScheduleId,
+	Long menteeId,
+	boolean cancelYn
+) {
+	public static MenteeScheduleResponseDto from(MenteeSchedule menteeSchedule) {
+		return new MenteeScheduleResponseDto(
+			menteeSchedule.getId(),
+			menteeSchedule.getCoachingScheduleId(),
+			menteeSchedule.getMenteeId(),
+			menteeSchedule.isCancelYn()
+		);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MenteeScheduleResponseDto.java
@@ -3,8 +3,8 @@ package cobook.buddywisdom.mentee.dto.response;
 import cobook.buddywisdom.mentee.domain.MenteeSchedule;
 
 public record MenteeScheduleResponseDto (
-	Long coachingScheduleId,
-	Long menteeId
+	long coachingScheduleId,
+	long menteeId
 ) {
 	public static MenteeScheduleResponseDto from(MenteeSchedule menteeSchedule) {
 		return new MenteeScheduleResponseDto(

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MyCoachScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MyCoachScheduleResponseDto.java
@@ -1,0 +1,21 @@
+package cobook.buddywisdom.mentee.dto.response;
+
+import java.time.LocalDateTime;
+
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+
+public record MyCoachScheduleResponseDto(
+	Long id,
+	Long coachId,
+	LocalDateTime possibleDateTime,
+	boolean matchYn
+) {
+	public static MyCoachScheduleResponseDto from(CoachSchedule coachSchedule) {
+		return new MyCoachScheduleResponseDto(
+			coachSchedule.getId(),
+			coachSchedule.getCoachId(),
+			coachSchedule.getPossibleDateTime(),
+			coachSchedule.isMatchYn()
+		);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/mentee/dto/response/MyCoachScheduleResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/response/MyCoachScheduleResponseDto.java
@@ -5,8 +5,8 @@ import java.time.LocalDateTime;
 import cobook.buddywisdom.coach.domain.CoachSchedule;
 
 public record MyCoachScheduleResponseDto(
-	Long id,
-	Long coachId,
+	long id,
+	long coachId,
 	LocalDateTime possibleDateTime,
 	boolean matchYn
 ) {

--- a/src/main/java/cobook/buddywisdom/mentee/exception/DuplicatedMenteeScheduleException.java
+++ b/src/main/java/cobook/buddywisdom/mentee/exception/DuplicatedMenteeScheduleException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.mentee.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class DuplicatedMenteeScheduleException extends RuntimeException {
+	public DuplicatedMenteeScheduleException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
@@ -12,8 +12,8 @@ import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 
 @Mapper
 public interface MenteeScheduleMapper {
-	List<MenteeMonthlySchedule> findAllByMenteeIdAndPossibleDateTime(Long menteeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
-	Optional<MenteeScheduleFeedback> findByMenteeIdAndCoachingScheduleId(Long menteeId, Long coachingScheduleId);
-	Optional<MenteeSchedule> findByCoachingScheduleId(Long coachingScheduleId);
+	List<MenteeMonthlySchedule> findAllByMenteeIdAndPossibleDateTime(long menteeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+	Optional<MenteeScheduleFeedback> findByMenteeIdAndCoachingScheduleId(long menteeId, long coachingScheduleId);
+	Optional<MenteeSchedule> findByCoachingScheduleId(long coachingScheduleId);
 	void save(MenteeSchedule menteeSchedule);
 }

--- a/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
@@ -1,6 +1,7 @@
 package cobook.buddywisdom.mentee.mapper;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -11,8 +12,8 @@ import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 
 @Mapper
 public interface MenteeScheduleMapper {
-	MenteeMonthlySchedule findByMenteeIdAndPossibleDateTime(Long menteeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+	List<MenteeMonthlySchedule> findAllByMenteeIdAndPossibleDateTime(Long menteeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 	Optional<MenteeScheduleFeedback> findByMenteeIdAndCoachingScheduleId(Long menteeId, Long coachingScheduleId);
-	Optional<MenteeSchedule> findByMenteeIdAndCoachingScheduleIdAndCancelYn(Long menteeId, Long coachingScheduleId, boolean cancelYn);
+	Optional<MenteeSchedule> findByCoachingScheduleId(Long coachingScheduleId);
 	void save(MenteeSchedule menteeSchedule);
 }

--- a/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
@@ -6,10 +6,13 @@ import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
+import cobook.buddywisdom.mentee.domain.MenteeSchedule;
 import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 
 @Mapper
 public interface MenteeScheduleMapper {
 	MenteeMonthlySchedule findByMenteeIdAndPossibleDateTime(Long menteeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 	Optional<MenteeScheduleFeedback> findByMenteeIdAndCoachingScheduleId(Long menteeId, Long coachingScheduleId);
+	Optional<MenteeSchedule> findByMenteeIdAndCoachingScheduleIdAndCancelYn(Long menteeId, Long coachingScheduleId, boolean cancelYn);
+	void save(MenteeSchedule menteeSchedule);
 }

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -6,12 +6,16 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cobook.buddywisdom.coach.service.CoachScheduleService;
 import cobook.buddywisdom.global.exception.ErrorMessage;
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
+import cobook.buddywisdom.mentee.domain.MenteeSchedule;
 import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
-import cobook.buddywisdom.mentee.dto.MenteeMonthlyScheduleResponse;
-import cobook.buddywisdom.mentee.dto.MenteeScheduleFeedbackResponse;
-import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
+import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
+import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
+import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
+import cobook.buddywisdom.mentee.dto.response.MenteeScheduleResponseDto;
+import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
 
@@ -20,24 +24,49 @@ import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
 public class MenteeScheduleService {
 
 	private final MenteeScheduleMapper menteeScheduleMapper;
+	private final CoachScheduleService coachScheduleService;
 
-	public MenteeScheduleService(MenteeScheduleMapper menteeScheduleMapper) {
+	public MenteeScheduleService(MenteeScheduleMapper menteeScheduleMapper, CoachScheduleService coachScheduleService) {
 		this.menteeScheduleMapper = menteeScheduleMapper;
+		this.coachScheduleService = coachScheduleService;
 	}
 
-	public List<MenteeMonthlyScheduleResponse> getMenteeMonthlySchedule(Long menteeId, MenteeMonthlyScheduleRequest request) {
+	public List<MenteeMonthlyScheduleResponseDto> getMenteeMonthlySchedule(Long menteeId, MenteeMonthlyScheduleRequestDto request) {
 		MenteeMonthlySchedule menteeMonthlySchedule =
 			menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(menteeId, request.startDateTime(), request.endDateTime());
 
 		return Optional.ofNullable(menteeMonthlySchedule)
-			.map(MenteeMonthlyScheduleResponse::from)
+			.map(MenteeMonthlyScheduleResponseDto::from)
 			.stream().toList();
 	}
 
-	public MenteeScheduleFeedbackResponse getMenteeScheduleFeedback(Long menteeId, Long coachingScheduleId) {
+	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(Long menteeId, Long coachingScheduleId) {
 		MenteeScheduleFeedback menteeScheduleFeedback = menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(menteeId, coachingScheduleId)
 			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
 
-		return MenteeScheduleFeedbackResponse.from(menteeScheduleFeedback);
+		return MenteeScheduleFeedbackResponseDto.from(menteeScheduleFeedback);
+	}
+
+	@Transactional
+	public MenteeScheduleResponseDto saveMenteeSchedule(Long menteeId, Long coachingScheduleId) {
+		coachScheduleService.getCoachSchedule(coachingScheduleId);
+
+		checkMenteeScheduleNotExist(menteeId, coachingScheduleId, false);
+
+		MenteeSchedule menteeSchedule = MenteeSchedule.of(coachingScheduleId, menteeId);
+		menteeScheduleMapper.save(menteeSchedule);
+
+		return MenteeScheduleResponseDto.from(menteeSchedule);
+	}
+
+	private void checkMenteeScheduleNotExist(Long menteeId, Long coachingScheduleId, boolean cancelYn) {
+		Optional<MenteeSchedule> menteeSchedule =
+			menteeScheduleMapper.findByMenteeIdAndCoachingScheduleIdAndCancelYn(menteeId, coachingScheduleId, cancelYn);
+
+		if (menteeSchedule.isEmpty()) {
+			return;
+		}
+
+		throw new DuplicatedMenteeScheduleException(ErrorMessage.DUPLICATED_MENTEE_SCHEDULE);
 	}
 }

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -1,8 +1,6 @@
 package cobook.buddywisdom.mentee.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,8 +46,10 @@ public class MenteeScheduleService {
 			menteeScheduleMapper.findAllByMenteeIdAndPossibleDateTime(menteeId, request.startDateTime(), request.endDateTime());
 
 		return Optional.ofNullable(menteeMonthlyScheduleList)
-			.map(m -> m.stream().map(MenteeMonthlyScheduleResponseDto::from).toList())
-			.orElseGet(Collections::emptyList);
+			.stream()
+			.flatMap(List::stream)
+			.map(MenteeMonthlyScheduleResponseDto::from)
+			.toList();
 	}
 
 	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(long menteeId, long coachingScheduleId) {
@@ -68,8 +68,10 @@ public class MenteeScheduleService {
 			coachScheduleService.getAllCoachingSchedule(coachingRelationship.getCoachId(), today, today.plusDays(DEFAULT_DAYS));
 
 		return Optional.ofNullable(coachScheduleList)
-			.map(m -> m.stream().map(MyCoachScheduleResponseDto::from).toList())
-			.orElseGet(Collections::emptyList);
+			.stream()
+			.flatMap(List::stream)
+			.map(MyCoachScheduleResponseDto::from)
+			.toList();
 	}
 
 	@Transactional

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -1,5 +1,7 @@
 package cobook.buddywisdom.mentee.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +34,8 @@ public class MenteeScheduleService {
 	private final CoachScheduleService coachScheduleService;
 	private final CoachingRelationshipService coachingRelationshipService;
 
+	private static final int DEFAULT_DAYS = 8;
+
 	public MenteeScheduleService(MenteeScheduleMapper menteeScheduleMapper, CoachScheduleService coachScheduleService,
 		CoachingRelationshipService coachingRelationshipService) {
 		this.menteeScheduleMapper = menteeScheduleMapper;
@@ -58,8 +62,10 @@ public class MenteeScheduleService {
 	public List<MyCoachScheduleResponseDto> getMyCoachSchedule(Long menteeId) {
 		CoachingRelationship coachingRelationship = coachingRelationshipService.getCoachingRelationshipByMenteeId(menteeId);
 
+		LocalDate today = LocalDate.now();
+
 		List<CoachSchedule> coachScheduleList =
-			coachScheduleService.getAllCoachingSchedule(coachingRelationship.getCoachId());
+			coachScheduleService.getAllCoachingSchedule(coachingRelationship.getCoachId(), today, today.plusDays(DEFAULT_DAYS));
 
 		return Optional.ofNullable(coachScheduleList)
 			.map(m -> m.stream().map(MyCoachScheduleResponseDto::from).toList())

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -3,6 +3,7 @@ package cobook.buddywisdom.mentee.service;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,7 +50,7 @@ public class MenteeScheduleService {
 			.stream()
 			.flatMap(List::stream)
 			.map(MenteeMonthlyScheduleResponseDto::from)
-			.toList();
+			.collect(Collectors.toUnmodifiableList());
 	}
 
 	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(long menteeId, long coachingScheduleId) {
@@ -71,7 +72,7 @@ public class MenteeScheduleService {
 			.stream()
 			.flatMap(List::stream)
 			.map(MyCoachScheduleResponseDto::from)
-			.toList();
+			.collect(Collectors.toUnmodifiableList());
 	}
 
 	@Transactional

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -43,7 +43,7 @@ public class MenteeScheduleService {
 		this.coachingRelationshipService = coachingRelationshipService;
 	}
 
-	public List<MenteeMonthlyScheduleResponseDto> getMenteeMonthlySchedule(Long menteeId, MenteeMonthlyScheduleRequestDto request) {
+	public List<MenteeMonthlyScheduleResponseDto> getMenteeMonthlySchedule(long menteeId, MenteeMonthlyScheduleRequestDto request) {
 		List<MenteeMonthlySchedule> menteeMonthlyScheduleList =
 			menteeScheduleMapper.findAllByMenteeIdAndPossibleDateTime(menteeId, request.startDateTime(), request.endDateTime());
 
@@ -52,14 +52,14 @@ public class MenteeScheduleService {
 			.orElseGet(Collections::emptyList);
 	}
 
-	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(Long menteeId, Long coachingScheduleId) {
+	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(long menteeId, long coachingScheduleId) {
 		MenteeScheduleFeedback menteeScheduleFeedback = menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(menteeId, coachingScheduleId)
 			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
 
 		return MenteeScheduleFeedbackResponseDto.from(menteeScheduleFeedback);
 	}
 
-	public List<MyCoachScheduleResponseDto> getMyCoachSchedule(Long menteeId) {
+	public List<MyCoachScheduleResponseDto> getMyCoachSchedule(long menteeId) {
 		CoachingRelationship coachingRelationship = coachingRelationshipService.getCoachingRelationshipByMenteeId(menteeId);
 
 		LocalDate today = LocalDate.now();
@@ -73,7 +73,7 @@ public class MenteeScheduleService {
 	}
 
 	@Transactional
-	public MenteeScheduleResponseDto saveMenteeSchedule(Long menteeId, Long coachingScheduleId) {
+	public MenteeScheduleResponseDto saveMenteeSchedule(long menteeId, long coachingScheduleId) {
 		coachScheduleService.getCoachSchedule(coachingScheduleId,false);
 
 		checkMenteeScheduleNotExist(coachingScheduleId);
@@ -86,7 +86,7 @@ public class MenteeScheduleService {
 		return MenteeScheduleResponseDto.from(menteeSchedule);
 	}
 
-	public void checkMenteeScheduleNotExist(Long coachingScheduleId) {
+	public void checkMenteeScheduleNotExist(long coachingScheduleId) {
 		Optional<MenteeSchedule> menteeSchedule = menteeScheduleMapper.findByCoachingScheduleId(coachingScheduleId);
 
 		if (menteeSchedule.isEmpty()) {

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -1,11 +1,13 @@
 package cobook.buddywisdom.mentee.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cobook.buddywisdom.coach.domain.CoachSchedule;
 import cobook.buddywisdom.coach.service.CoachScheduleService;
 import cobook.buddywisdom.global.exception.ErrorMessage;
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
@@ -15,9 +17,12 @@ import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleResponseDto;
+import cobook.buddywisdom.mentee.dto.response.MyCoachScheduleResponseDto;
 import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
+import cobook.buddywisdom.relationship.domain.CoachingRelationship;
+import cobook.buddywisdom.relationship.service.CoachingRelationshipService;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,19 +30,22 @@ public class MenteeScheduleService {
 
 	private final MenteeScheduleMapper menteeScheduleMapper;
 	private final CoachScheduleService coachScheduleService;
+	private final CoachingRelationshipService coachingRelationshipService;
 
-	public MenteeScheduleService(MenteeScheduleMapper menteeScheduleMapper, CoachScheduleService coachScheduleService) {
+	public MenteeScheduleService(MenteeScheduleMapper menteeScheduleMapper, CoachScheduleService coachScheduleService,
+		CoachingRelationshipService coachingRelationshipService) {
 		this.menteeScheduleMapper = menteeScheduleMapper;
 		this.coachScheduleService = coachScheduleService;
+		this.coachingRelationshipService = coachingRelationshipService;
 	}
 
 	public List<MenteeMonthlyScheduleResponseDto> getMenteeMonthlySchedule(Long menteeId, MenteeMonthlyScheduleRequestDto request) {
-		MenteeMonthlySchedule menteeMonthlySchedule =
-			menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(menteeId, request.startDateTime(), request.endDateTime());
+		List<MenteeMonthlySchedule> menteeMonthlyScheduleList =
+			menteeScheduleMapper.findAllByMenteeIdAndPossibleDateTime(menteeId, request.startDateTime(), request.endDateTime());
 
-		return Optional.ofNullable(menteeMonthlySchedule)
-			.map(MenteeMonthlyScheduleResponseDto::from)
-			.stream().toList();
+		return Optional.ofNullable(menteeMonthlyScheduleList)
+			.map(m -> m.stream().map(MenteeMonthlyScheduleResponseDto::from).toList())
+			.orElseGet(Collections::emptyList);
 	}
 
 	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(Long menteeId, Long coachingScheduleId) {
@@ -47,21 +55,33 @@ public class MenteeScheduleService {
 		return MenteeScheduleFeedbackResponseDto.from(menteeScheduleFeedback);
 	}
 
+	public List<MyCoachScheduleResponseDto> getMyCoachSchedule(Long menteeId) {
+		CoachingRelationship coachingRelationship = coachingRelationshipService.getCoachingRelationshipByMenteeId(menteeId);
+
+		List<CoachSchedule> coachScheduleList =
+			coachScheduleService.getAllCoachingSchedule(coachingRelationship.getCoachId());
+
+		return Optional.ofNullable(coachScheduleList)
+			.map(m -> m.stream().map(MyCoachScheduleResponseDto::from).toList())
+			.orElseGet(Collections::emptyList);
+	}
+
 	@Transactional
 	public MenteeScheduleResponseDto saveMenteeSchedule(Long menteeId, Long coachingScheduleId) {
 		coachScheduleService.getCoachSchedule(coachingScheduleId);
 
-		checkMenteeScheduleNotExist(menteeId, coachingScheduleId, false);
+		checkMenteeScheduleNotExist(coachingScheduleId);
 
 		MenteeSchedule menteeSchedule = MenteeSchedule.of(coachingScheduleId, menteeId);
 		menteeScheduleMapper.save(menteeSchedule);
 
+		coachScheduleService.updateMatchYn(coachingScheduleId, true);
+
 		return MenteeScheduleResponseDto.from(menteeSchedule);
 	}
 
-	private void checkMenteeScheduleNotExist(Long menteeId, Long coachingScheduleId, boolean cancelYn) {
-		Optional<MenteeSchedule> menteeSchedule =
-			menteeScheduleMapper.findByMenteeIdAndCoachingScheduleIdAndCancelYn(menteeId, coachingScheduleId, cancelYn);
+	public void checkMenteeScheduleNotExist(Long coachingScheduleId) {
+		Optional<MenteeSchedule> menteeSchedule = menteeScheduleMapper.findByCoachingScheduleId(coachingScheduleId);
 
 		if (menteeSchedule.isEmpty()) {
 			return;

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -68,7 +68,7 @@ public class MenteeScheduleService {
 
 	@Transactional
 	public MenteeScheduleResponseDto saveMenteeSchedule(Long menteeId, Long coachingScheduleId) {
-		coachScheduleService.getCoachSchedule(coachingScheduleId);
+		coachScheduleService.getCoachSchedule(coachingScheduleId,false);
 
 		checkMenteeScheduleNotExist(coachingScheduleId);
 

--- a/src/main/java/cobook/buddywisdom/relationship/domain/CoachingRelationship.java
+++ b/src/main/java/cobook/buddywisdom/relationship/domain/CoachingRelationship.java
@@ -1,0 +1,28 @@
+package cobook.buddywisdom.relationship.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoachingRelationship {
+	private Long id;
+	private Long coachId;
+	private Long menteeId;
+	private boolean activeYn;
+	private LocalDateTime startedAt;
+	private LocalDateTime expiredAt;
+
+	public static CoachingRelationship of(Long coachId, Long menteeId, boolean activeYn, LocalDateTime startedAt, LocalDateTime expiredAt) {
+		CoachingRelationship coachingRelationship = new CoachingRelationship();
+		coachingRelationship.coachId = coachId;
+		coachingRelationship.menteeId = menteeId;
+		coachingRelationship.activeYn = activeYn;
+		coachingRelationship.startedAt = startedAt;
+		coachingRelationship.expiredAt = expiredAt;
+		return coachingRelationship;
+	}
+}

--- a/src/main/java/cobook/buddywisdom/relationship/exception/NotFoundRelationshipException.java
+++ b/src/main/java/cobook/buddywisdom/relationship/exception/NotFoundRelationshipException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.relationship.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class NotFoundRelationshipException extends RuntimeException {
+	public NotFoundRelationshipException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/relationship/mapper/CoachingRelationshipMapper.java
+++ b/src/main/java/cobook/buddywisdom/relationship/mapper/CoachingRelationshipMapper.java
@@ -8,5 +8,5 @@ import cobook.buddywisdom.relationship.domain.CoachingRelationship;
 
 @Mapper
 public interface CoachingRelationshipMapper {
-	Optional<CoachingRelationship> findByMenteeId(Long menteeId);
+	Optional<CoachingRelationship> findByMenteeId(long menteeId);
 }

--- a/src/main/java/cobook/buddywisdom/relationship/mapper/CoachingRelationshipMapper.java
+++ b/src/main/java/cobook/buddywisdom/relationship/mapper/CoachingRelationshipMapper.java
@@ -1,0 +1,12 @@
+package cobook.buddywisdom.relationship.mapper;
+
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import cobook.buddywisdom.relationship.domain.CoachingRelationship;
+
+@Mapper
+public interface CoachingRelationshipMapper {
+	Optional<CoachingRelationship> findByMenteeId(Long menteeId);
+}

--- a/src/main/java/cobook/buddywisdom/relationship/service/CoachingRelationshipService.java
+++ b/src/main/java/cobook/buddywisdom/relationship/service/CoachingRelationshipService.java
@@ -2,7 +2,6 @@ package cobook.buddywisdom.relationship.service;
 
 import org.springframework.stereotype.Service;
 
-import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
 import cobook.buddywisdom.global.exception.ErrorMessage;
 import cobook.buddywisdom.relationship.domain.CoachingRelationship;
 import cobook.buddywisdom.relationship.exception.NotFoundRelationshipException;
@@ -17,7 +16,7 @@ public class CoachingRelationshipService {
 		this.coachingRelationshipMapper = coachingRelationshipMapper;
 	}
 
-	public CoachingRelationship getCoachingRelationshipByMenteeId(Long menteeId) {
+	public CoachingRelationship getCoachingRelationshipByMenteeId(long menteeId) {
 		return coachingRelationshipMapper.findByMenteeId(menteeId)
 			.orElseThrow(() -> new NotFoundRelationshipException(ErrorMessage.NOT_FOUND_COACHING_RELATIONSHIP));
 	}

--- a/src/main/java/cobook/buddywisdom/relationship/service/CoachingRelationshipService.java
+++ b/src/main/java/cobook/buddywisdom/relationship/service/CoachingRelationshipService.java
@@ -1,0 +1,24 @@
+package cobook.buddywisdom.relationship.service;
+
+import org.springframework.stereotype.Service;
+
+import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
+import cobook.buddywisdom.global.exception.ErrorMessage;
+import cobook.buddywisdom.relationship.domain.CoachingRelationship;
+import cobook.buddywisdom.relationship.exception.NotFoundRelationshipException;
+import cobook.buddywisdom.relationship.mapper.CoachingRelationshipMapper;
+
+@Service
+public class CoachingRelationshipService {
+
+	private final CoachingRelationshipMapper coachingRelationshipMapper;
+
+	public CoachingRelationshipService(CoachingRelationshipMapper coachingRelationshipMapper) {
+		this.coachingRelationshipMapper = coachingRelationshipMapper;
+	}
+
+	public CoachingRelationship getCoachingRelationshipByMenteeId(Long menteeId) {
+		return coachingRelationshipMapper.findByMenteeId(menteeId)
+			.orElseThrow(() -> new NotFoundRelationshipException(ErrorMessage.NOT_FOUND_COACHING_RELATIONSHIP));
+	}
+}

--- a/src/main/resources/mapper/coach/CoachScheduleMapper.xml
+++ b/src/main/resources/mapper/coach/CoachScheduleMapper.xml
@@ -5,12 +5,14 @@
 
 <mapper namespace="cobook.buddywisdom.coach.mapper.CoachScheduleMapper">
 
-    <select id="findById" parameterType="map" resultType="CoachSchedule">
+    <select id="findByIdAndMatchYn" parameterType="map" resultType="CoachSchedule">
         SELECT id,
                coach_id,
-               possible_date_time
+               possible_date_time,
+               match_yn
         FROM coaching_schedule
         WHERE id = #{id}
+            AND match_yn = #{matchYn}
     </select>
 
     <select id="findAllByCoachId" parameterType="map" resultType="CoachSchedule">

--- a/src/main/resources/mapper/coach/CoachScheduleMapper.xml
+++ b/src/main/resources/mapper/coach/CoachScheduleMapper.xml
@@ -13,4 +13,19 @@
         WHERE id = #{id}
     </select>
 
+    <select id="findAllByCoachId" parameterType="map" resultType="CoachSchedule">
+        SELECT id,
+               coach_id,
+               possible_date_time,
+               match_yn
+        FROM coaching_schedule
+        WHERE coach_id = #{id}
+    </select>
+
+    <update id="setMatchYn" parameterType="map">
+        UPDATE coaching_schedule
+        SET match_yn = #{matchYn}
+        WHERE id = #{id}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/coach/CoachScheduleMapper.xml
+++ b/src/main/resources/mapper/coach/CoachScheduleMapper.xml
@@ -15,13 +15,14 @@
             AND match_yn = #{matchYn}
     </select>
 
-    <select id="findAllByCoachId" parameterType="map" resultType="CoachSchedule">
+    <select id="findAllByCoachIdAndPossibleDateTime" parameterType="map" resultType="CoachSchedule">
         SELECT id,
                coach_id,
                possible_date_time,
                match_yn
         FROM coaching_schedule
-        WHERE coach_id = #{id}
+        WHERE coach_id = #{coachId}
+            AND possible_date_time BETWEEN #{startDateTime} AND #{endDateTime}
     </select>
 
     <update id="setMatchYn" parameterType="map">

--- a/src/main/resources/mapper/coach/CoachScheduleMapper.xml
+++ b/src/main/resources/mapper/coach/CoachScheduleMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="cobook.buddywisdom.coach.mapper.CoachScheduleMapper">
+
+    <select id="findById" parameterType="map" resultType="CoachSchedule">
+        SELECT id,
+               coach_id,
+               possible_date_time
+        FROM coaching_schedule
+        WHERE id = #{id}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
+++ b/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
@@ -32,4 +32,29 @@
             AND ms.coaching_schedule_id = #{coachingScheduleId};
     </select>
 
+    <select id="findByMenteeIdAndCoachingScheduleIdAndCancelYn" parameterType="map" resultType="MenteeSchedule">
+        SELECT id,
+               coaching_schedule_id,
+               mentee_id,
+               cancel_yn
+        FROM mentee_schedule
+        WHERE mentee_id = #{menteeId}
+            AND coaching_schedule_id = #{coachingScheduleId}
+            AND cancel_yn = #{cancelYn}
+    </select>
+
+    <insert id="save" parameterType="MenteeSchedule" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO mentee_schedule(coaching_schedule_id,
+                                    mentee_id)
+        VALUES (#{coachingScheduleId},
+                #{menteeId})
+        <selectKey keyProperty="id,cancelYn" resultType="MenteeSchedule" order="AFTER">
+            SELECT id,
+                   cancel_yn
+            FROM mentee_schedule
+            WHERE mentee_id = #{menteeId}
+                AND coaching_schedule_id = #{coachingScheduleId};
+        </selectKey>
+    </insert>
+
 </mapper>

--- a/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
+++ b/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
@@ -5,20 +5,18 @@
 
 <mapper namespace="cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper">
 
-    <select id="findByMenteeIdAndPossibleDateTime" parameterType="map" resultType="MenteeMonthlySchedule">
-        SELECT ms.id,
-               ms.coaching_schedule_id,
-               ms.cancel_yn,
+    <select id="findAllByMenteeIdAndPossibleDateTime" parameterType="map" resultType="MenteeMonthlySchedule">
+        SELECT ms.coaching_schedule_id,
                cs.possible_date_time
         FROM mentee_schedule ms
         JOIN coaching_schedule cs
             ON ms.coaching_schedule_id = cs.id
         WHERE mentee_id = #{menteeId}
-            AND cs.possible_date_time BETWEEN #{startDateTime} AND #{endDateTime};
+            AND cs.possible_date_time BETWEEN #{startDateTime} AND #{endDateTime}
     </select>
 
     <select id="findByMenteeIdAndCoachingScheduleId" parameterType="map" resultType="MenteeScheduleFeedback">
-        SELECT ms.id,
+        SELECT ms.coaching_schedule_id,
                cs.possible_date_time,
                fb.id AS feedback_id,
                fb.coach_feedback,
@@ -27,34 +25,21 @@
         JOIN coaching_schedule cs
             ON ms.coaching_schedule_id = cs.id
         LEFT JOIN feedback fb
-            ON ms.id = fb.mentee_schedule_id
+            ON ms.coaching_schedule_id = fb.mentee_schedule_id
         WHERE ms.mentee_id = #{menteeId}
-            AND ms.coaching_schedule_id = #{coachingScheduleId};
+            AND ms.coaching_schedule_id = #{coachingScheduleId}
     </select>
 
-    <select id="findByMenteeIdAndCoachingScheduleIdAndCancelYn" parameterType="map" resultType="MenteeSchedule">
-        SELECT id,
-               coaching_schedule_id,
-               mentee_id,
-               cancel_yn
+    <select id="findByCoachingScheduleId" parameterType="map" resultType="MenteeSchedule">
+        SELECT coaching_schedule_id,
+               mentee_id
         FROM mentee_schedule
-        WHERE mentee_id = #{menteeId}
-            AND coaching_schedule_id = #{coachingScheduleId}
-            AND cancel_yn = #{cancelYn}
+        WHERE coaching_schedule_id = #{coachingScheduleId}
     </select>
 
     <insert id="save" parameterType="MenteeSchedule" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO mentee_schedule(coaching_schedule_id,
-                                    mentee_id)
-        VALUES (#{coachingScheduleId},
-                #{menteeId})
-        <selectKey keyProperty="id,cancelYn" resultType="MenteeSchedule" order="AFTER">
-            SELECT id,
-                   cancel_yn
-            FROM mentee_schedule
-            WHERE mentee_id = #{menteeId}
-                AND coaching_schedule_id = #{coachingScheduleId};
-        </selectKey>
+        INSERT INTO mentee_schedule(coaching_schedule_id, mentee_id)
+        VALUES (#{coachingScheduleId}, #{menteeId})
     </insert>
 
 </mapper>

--- a/src/main/resources/mapper/relationship/CoachingRelationshipMapper.xml
+++ b/src/main/resources/mapper/relationship/CoachingRelationshipMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="cobook.buddywisdom.relationship.mapper.CoachingRelationshipMapper">
+
+    <select id="findByMenteeId" parameterType="Long" resultType="CoachingRelationship">
+        SELECT id,
+               coach_id,
+               mentee_id,
+               active_yn,
+               started_at,
+               expired_at
+        FROM coaching_relationship
+        WHERE mentee_id = #{menteeId}
+    </select>
+
+</mapper>

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
+import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
 import cobook.buddywisdom.mentee.service.MenteeScheduleService;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
@@ -49,7 +49,7 @@ public class MenteeControllerTest {
 			LocalDateTime startDateTime = LocalDateTime.parse(firstDayOfMonth + "T00:00:00");
 			LocalDateTime endDateTime = LocalDateTime.parse(LocalDate.now().withDayOfMonth(firstDayOfMonth.lengthOfMonth()) + "T23:59:59");
 
-			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(startDateTime, endDateTime);
+			MenteeMonthlyScheduleRequestDto request = new MenteeMonthlyScheduleRequestDto(startDateTime, endDateTime);
 
 			ResultActions response =
 				mockMvc.perform(
@@ -66,7 +66,7 @@ public class MenteeControllerTest {
 		@WithMockCustomUser(role = "MENTEE")
 		@DisplayName("일정 정보가 null 값이라면 400 Bad Request가 반환된다.")
 		void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail() throws Exception {
-			MenteeMonthlyScheduleRequest request = new MenteeMonthlyScheduleRequest(null, null);
+			MenteeMonthlyScheduleRequestDto request = new MenteeMonthlyScheduleRequestDto(null, null);
 
 			ResultActions response =
 				mockMvc.perform(

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -40,9 +41,9 @@ public class MenteeControllerTest {
 
 	@Nested
 	@DisplayName("월별 스케줄 조회")
+	@WithMockCustomUser(role = "MENTEE")
 	class MonthlyScheduleTest {
 		@Test
-		@WithMockCustomUser(role = "MENTEE")
 		@DisplayName("일정 정보가 모두 전달되면 메서드를 호출하고 200 OK를 반환한다.")
 		void when_dateIsValid_expect_callMethodAndReturn200Ok() throws Exception {
 			LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
@@ -63,7 +64,6 @@ public class MenteeControllerTest {
 		}
 
 		@Test
-		@WithMockCustomUser(role = "MENTEE")
 		@DisplayName("일정 정보가 null 값이라면 400 Bad Request가 반환된다.")
 		void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail() throws Exception {
 			MenteeMonthlyScheduleRequestDto request = new MenteeMonthlyScheduleRequestDto(null, null);
@@ -94,6 +94,39 @@ public class MenteeControllerTest {
 				.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(menteeScheduleService).getMenteeScheduleFeedback(BDDMockito.anyLong(), BDDMockito.anyLong());
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+	}
+	@Nested
+	@DisplayName("코칭 신청")
+	@WithMockCustomUser(role = "MENTEE")
+	class CreateScheduleTest {
+		@Test
+		@DisplayName("인증된 멘티 정보가 존재하면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_authenticatedMenteeExists_expect_callMethodAndReturn200Ok() throws Exception {
+			Long authenticatedId = 1L;
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.get("/api/v1/mentees/schedule/create"))
+					.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(menteeScheduleService).getMyCoachSchedule(authenticatedId);
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@Test
+		@DisplayName("유효한 스케줄 id가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_scheduleIdIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+			Long scheduleId = 1L;
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.post("/api/v1/mentees/schedule/create/" + scheduleId)
+							.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(menteeScheduleService).saveMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 	}

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -54,7 +54,7 @@ public class MenteeControllerTest {
 
 			ResultActions response =
 				mockMvc.perform(
-					MockMvcRequestBuilders.get("/api/v1/mentees/schedule")
+					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/monthly")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsBytes(request)))
 				.andDo(MockMvcResultHandlers.print());
@@ -70,7 +70,7 @@ public class MenteeControllerTest {
 
 			ResultActions response =
 				mockMvc.perform(
-					MockMvcRequestBuilders.get("/api/v1/mentees/schedule")
+					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/monthly")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsBytes(request)))
 				.andDo(MockMvcResultHandlers.print());
@@ -90,7 +90,7 @@ public class MenteeControllerTest {
 
 			ResultActions response =
 				mockMvc.perform(
-					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/feedback/" + scheduleId))
+					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/" + scheduleId))
 				.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(menteeScheduleService).getMenteeScheduleFeedback(BDDMockito.anyLong(), BDDMockito.anyLong());
@@ -108,7 +108,7 @@ public class MenteeControllerTest {
 
 			ResultActions response =
 				mockMvc.perform(
-						MockMvcRequestBuilders.get("/api/v1/mentees/schedule/create"))
+						MockMvcRequestBuilders.get("/api/v1/mentees/schedule"))
 					.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(menteeScheduleService).getMyCoachSchedule(authenticatedId);
@@ -122,7 +122,7 @@ public class MenteeControllerTest {
 
 			ResultActions response =
 				mockMvc.perform(
-						MockMvcRequestBuilders.post("/api/v1/mentees/schedule/create/" + scheduleId)
+						MockMvcRequestBuilders.post("/api/v1/mentees/schedule/" + scheduleId)
 							.with(SecurityMockMvcRequestPostProcessors.csrf()))
 					.andDo(MockMvcResultHandlers.print());
 

--- a/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
@@ -183,7 +183,7 @@ public class MenteeServiceTest {
 			Long menteeId = 1L;
 			Long notExistScheduleId = 1L;
 
-			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.any()))
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
 				.willThrow(NotFoundCoachScheduleException.class);
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->

--- a/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
@@ -19,9 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
 import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
-import cobook.buddywisdom.mentee.dto.MenteeMonthlyScheduleResponse;
-import cobook.buddywisdom.mentee.dto.MenteeScheduleFeedbackResponse;
-import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequest;
+import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
+import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
+import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
 
@@ -47,7 +47,7 @@ public class MenteeServiceTest {
 			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
 				.willReturn(menteeMonthlySchedule);
 
-			List<MenteeMonthlyScheduleResponse> expectedResponse =
+			List<MenteeMonthlyScheduleResponseDto> expectedResponse =
 				menteeScheduleService.getMenteeMonthlySchedule(menteeId, getMenteeMonthlyScheduleRequest());
 
 			Assertions.assertNotNull(expectedResponse);
@@ -63,7 +63,7 @@ public class MenteeServiceTest {
 				.given(menteeScheduleMapper.findByMenteeIdAndPossibleDateTime(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
 				.willReturn(null);
 
-			List<MenteeMonthlyScheduleResponse> expectedResponse =
+			List<MenteeMonthlyScheduleResponseDto> expectedResponse =
 				menteeScheduleService.getMenteeMonthlySchedule(menteeId, getMenteeMonthlyScheduleRequest());
 
 			Assertions.assertTrue(expectedResponse.isEmpty());
@@ -86,7 +86,7 @@ public class MenteeServiceTest {
 			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
 				.willReturn(Optional.of(menteeScheduleFeedback));
 
-			MenteeScheduleFeedbackResponse expectedResponse =
+			MenteeScheduleFeedbackResponseDto expectedResponse =
 				menteeScheduleService.getMenteeScheduleFeedback(menteeId, scheduleId);
 
 			Assertions.assertNotNull(expectedResponse);
@@ -108,11 +108,11 @@ public class MenteeServiceTest {
 		}
 	}
 
-	public static MenteeMonthlyScheduleRequest getMenteeMonthlyScheduleRequest() {
+	public static MenteeMonthlyScheduleRequestDto getMenteeMonthlyScheduleRequest() {
 		LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
 		LocalDateTime startDateTime = LocalDateTime.parse(firstDayOfMonth + "T00:00:00");
 		LocalDateTime endDateTime = LocalDateTime.parse(LocalDate.now().withDayOfMonth(firstDayOfMonth.lengthOfMonth()) + "T23:59:59");
 
-		return new MenteeMonthlyScheduleRequest(startDateTime, endDateTime);
+		return new MenteeMonthlyScheduleRequestDto(startDateTime, endDateTime);
 	}
 }

--- a/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/service/MenteeServiceTest.java
@@ -137,11 +137,11 @@ public class MenteeServiceTest {
 				CoachingRelationship.of(coachId, menteeId, true, LocalDateTime.now(), LocalDateTime.now().plusMonths(2));
 			CoachSchedule coachSchedule = CoachSchedule.of(coachId, LocalDateTime.now(), false);
 
-			BDDMockito.given(coachScheduleService.getAllCoachingSchedule(BDDMockito.anyLong()))
+			BDDMockito.given(coachScheduleService.getAllCoachingSchedule(BDDMockito.anyLong(), BDDMockito.any(), BDDMockito.any()))
 				.willReturn(List.of(coachSchedule));
 
 			List<CoachSchedule> expectedResponse =
-				coachScheduleService.getAllCoachingSchedule(coachingRelationship.getCoachId());
+				coachScheduleService.getAllCoachingSchedule(coachingRelationship.getCoachId(), LocalDate.now(), LocalDate.now().plusDays(8));
 
 			Assertions.assertNotNull(expectedResponse);
 			Assertions.assertEquals(1, expectedResponse.size());


### PR DESCRIPTION
### 작업 내용
- 해당 멘티와 매칭된 코치의 일정 정보(`coaching_relationship`)를 조회한다.
- `coachingScheduleId`와 일치하면서 아직 매칭되지 않은 코칭 일정의 존재 여부를 확인한다.
- `coachingScheduleId`와`menteeId`정보로 일정을 신청한다.
- 코칭 스케줄(`coach_schedule`)에서 해당 `coachingScheduleId`을 가지는 row의 `match_yn`을 `true`로 변경한다.

<br>

### 참고 내용
- `mentee_schedule` 테이블 : `cancel_yn` 컬럼 삭제 적용
- `coach_schedule` 테이블 : 매칭 여부 확인을 위한 `match_yn` 컬럼 추가 적용