### PR TITLE
[#19] 멘티 일정 수정 기능을 구현한다.

### DIFF
--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
 	// MENTEE
 	NOT_FOUND_MENTEE_SCHEDULE(HttpStatus.NOT_FOUND, "등록된 멘티 스케줄이 존재하지 않습니다."),
 	DUPLICATED_MENTEE_SCHEDULE(HttpStatus.BAD_REQUEST, "이미 해당 코칭 일정으로 등록된 스케줄이 존재합니다."),
+	NOT_ALLOWED_UPDATE_SCHEDULE(HttpStatus.BAD_REQUEST, "변경 가능 시간이 지났으므로 취소 요청을 진행해 주세요."),
 
 	// COACH
 	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "이미 신청이 마감되었거나 존재하지 않는 스케줄입니다."),

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import cobook.buddywisdom.global.security.CustomUserDetails;
+import cobook.buddywisdom.mentee.dto.request.UpdateMenteeScheduleRequestDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
@@ -51,5 +53,11 @@ public class MenteeController {
 	public ResponseEntity<MenteeScheduleResponseDto> createMenteeSchedule(@AuthenticationPrincipal CustomUserDetails member,
 																			@PathVariable final long scheduleId) {
 		return ResponseEntity.ok(menteeScheduleService.saveMenteeSchedule(member.getId(), scheduleId));
+	}
+
+	@PatchMapping(value = "/schedule")
+	public ResponseEntity<Void> update(@RequestBody @Valid UpdateMenteeScheduleRequestDto request) {
+		menteeScheduleService.updateMenteeSchedule(request);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/cobook/buddywisdom/mentee/dto/request/UpdateMenteeScheduleRequestDto.java
+++ b/src/main/java/cobook/buddywisdom/mentee/dto/request/UpdateMenteeScheduleRequestDto.java
@@ -1,0 +1,11 @@
+package cobook.buddywisdom.mentee.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateMenteeScheduleRequestDto (
+	@NotNull(message = "기존 일정 정보를 선택해 주세요.")
+	Long currentCoachingId,
+	@NotNull(message = "변경하려는 일정 정보를 선택해 주세요.")
+	Long newCoachingId
+) {
+}

--- a/src/main/java/cobook/buddywisdom/mentee/exception/NotAllowedUpdateException.java
+++ b/src/main/java/cobook/buddywisdom/mentee/exception/NotAllowedUpdateException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.mentee.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class NotAllowedUpdateException extends RuntimeException {
+	public NotAllowedUpdateException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
@@ -16,4 +16,5 @@ public interface MenteeScheduleMapper {
 	Optional<MenteeScheduleFeedback> findByMenteeIdAndCoachingScheduleId(long menteeId, long coachingScheduleId);
 	Optional<MenteeSchedule> findByCoachingScheduleId(long coachingScheduleId);
 	void save(MenteeSchedule menteeSchedule);
+	void updateCoachingScheduleId(long currentCoachingId, long newCoachingId);
 }

--- a/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
+++ b/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
@@ -37,9 +37,15 @@
         WHERE coaching_schedule_id = #{coachingScheduleId}
     </select>
 
-    <insert id="save" parameterType="MenteeSchedule" useGeneratedKeys="true" keyProperty="id">
+    <insert id="save" parameterType="MenteeSchedule">
         INSERT INTO mentee_schedule(coaching_schedule_id, mentee_id)
         VALUES (#{coachingScheduleId}, #{menteeId})
     </insert>
+
+    <update id="updateCoachingScheduleId" parameterType="map">
+        UPDATE mentee_schedule
+        SET coaching_schedule_id = #{newCoachingId}
+        WHERE coaching_schedule_id = #{currentCoachingId}
+    </update>
 
 </mapper>

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
+import cobook.buddywisdom.mentee.dto.request.UpdateMenteeScheduleRequestDto;
 import cobook.buddywisdom.mentee.service.MenteeScheduleService;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
@@ -128,6 +129,48 @@ public class MenteeControllerTest {
 
 			BDDMockito.verify(menteeScheduleService).saveMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 일정 변경")
+	@WithMockCustomUser(role = "MENTEE")
+	class UpdateScheduleTest {
+
+		@Test
+		@DisplayName("스케줄 정보가 모두 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_scheduleInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+			UpdateMenteeScheduleRequestDto request =
+				new UpdateMenteeScheduleRequestDto(1L, 2L);
+
+			BDDMockito.willDoNothing().given(menteeScheduleService).updateMenteeSchedule(BDDMockito.any());
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.patch("/api/v1/mentees/schedule")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(request))
+							.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(menteeScheduleService).updateMenteeSchedule(BDDMockito.any(UpdateMenteeScheduleRequestDto.class));
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@Test
+		@DisplayName("스케줄 정보가 null 값이라면 400 Bad Request가 반환된다.")
+		void when_scheduleInformationIsNull_expect_return400BadRequest() throws Exception {
+			UpdateMenteeScheduleRequestDto request = new UpdateMenteeScheduleRequestDto(null, null);
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.patch("/api/v1/mentees/schedule")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(request))
+							.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
 		}
 	}
 }

--- a/src/test/java/cobook/buddywisdom/mentee/service/MenteeScheduleServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/service/MenteeScheduleServiceTest.java
@@ -16,6 +16,12 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import cobook.buddywisdom.coach.domain.CoachSchedule;
 import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
@@ -23,17 +29,20 @@ import cobook.buddywisdom.coach.service.CoachScheduleService;
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
 import cobook.buddywisdom.mentee.domain.MenteeSchedule;
 import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
+import cobook.buddywisdom.mentee.dto.request.UpdateMenteeScheduleRequestDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleResponseDto;
 import cobook.buddywisdom.mentee.dto.response.MyCoachScheduleResponseDto;
 import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
+import cobook.buddywisdom.mentee.exception.NotAllowedUpdateException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
 import cobook.buddywisdom.relationship.domain.CoachingRelationship;
 import cobook.buddywisdom.relationship.exception.NotFoundRelationshipException;
 import cobook.buddywisdom.relationship.service.CoachingRelationshipService;
+import cobook.buddywisdom.util.WithMockCustomUser;
 
 @ExtendWith(MockitoExtension.class)
 public class MenteeScheduleServiceTest {
@@ -188,14 +197,100 @@ public class MenteeScheduleServiceTest {
 		@Test
 		@DisplayName("멘티 스케줄이 이미 존재하면 DuplicatedMenteeScheduleException이 발생한다.")
 		void when_menteeScheduleExists_expect_throwsDuplicatedMenteeScheduleException() {
-			Long scheduleId = 1L;
-
 			BDDMockito.given(menteeScheduleMapper.findByCoachingScheduleId(BDDMockito.anyLong()))
 				.willThrow(DuplicatedMenteeScheduleException.class);
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->
-					menteeScheduleService.checkMenteeScheduleNotExist(scheduleId))
+					menteeScheduleService.checkMenteeScheduleNotExist(SCHEDULE_ID))
 				.isInstanceOf(DuplicatedMenteeScheduleException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 일정 변경")
+	@WithMockCustomUser(role = "MENTEE")
+	class UpdateScheduleTest {
+
+		@Test
+		@DisplayName("스케줄 정보가 모두 전달되면 일정을 변경하고 각 스케줄의 상태 값을 변경한다.")
+		void when_scheduleInformationIsValid_expect_callMethodAndReturn200Ok() {
+			long currentCoachingId = 1L;
+			long newCoachingId = 1L;
+
+			UpdateMenteeScheduleRequestDto request =
+				new UpdateMenteeScheduleRequestDto(currentCoachingId, newCoachingId);
+
+			CoachSchedule currentCoachSchedule = CoachSchedule.of(currentCoachingId, COACH_ID, LocalDateTime.now(), true);
+			CoachSchedule newCoachSchedule = CoachSchedule.of(newCoachingId, COACH_ID, LocalDateTime.now(), false);
+
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+					.willReturn(currentCoachSchedule);
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+					.willReturn(newCoachSchedule);
+			BDDMockito.willDoNothing().given(menteeScheduleMapper).updateCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong());
+			BDDMockito.willDoNothing().given(coachScheduleService).updateMatchYn(BDDMockito.anyLong(), BDDMockito.anyBoolean());
+
+			menteeScheduleService.updateMenteeSchedule(request);
+
+			BDDMockito.verify(coachScheduleService).getCoachSchedule(currentCoachingId, true);
+			BDDMockito.verify(coachScheduleService).getCoachSchedule(newCoachingId, false);
+			BDDMockito.verify(menteeScheduleMapper).updateCoachingScheduleId(currentCoachingId, newCoachingId);
+			BDDMockito.verify(coachScheduleService).updateMatchYn(currentCoachingId, false);
+			BDDMockito.verify(coachScheduleService).updateMatchYn(newCoachingId, true);
+		}
+
+		@Test
+		@DisplayName("일정 변경 시간이 지났다면 NotAllowedUpdateException이 발생한다.")
+		void when_timeHasPassed_expect_throwsNotAllowedUpdateException() {
+			UpdateMenteeScheduleRequestDto request = new UpdateMenteeScheduleRequestDto(1L, 2L);
+			CoachSchedule currentCoachSchedule = CoachSchedule.of(1L, COACH_ID, LocalDateTime.now().minusDays(1), true);
+
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+				.willReturn(currentCoachSchedule);
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					menteeScheduleService.checkIfUpdatePossible(request))
+				.isInstanceOf(NotAllowedUpdateException.class);
+		}
+
+		@Test
+		@DisplayName("일정 변경 시간이 지나지 않았다면 변경 가능함이 확인된다.")
+		void when_timeHasNotPassed_expect_validateUpdatePossibility() {
+			UpdateMenteeScheduleRequestDto request = new UpdateMenteeScheduleRequestDto(1L, 2L);
+			CoachSchedule currentCoachSchedule = CoachSchedule.of(1L, COACH_ID, LocalDateTime.now().plusDays(1), true);
+
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+				.willReturn(currentCoachSchedule);
+
+			menteeScheduleService.checkIfUpdatePossible(request);
+
+			BDDMockito.verify(coachScheduleService).getCoachSchedule(1L, true);
+		}
+
+		@Test
+		@DisplayName("기존 스케줄 정보가 존재하지 않는다면 NotFoundCoachScheduleException이 발생한다.")
+		void when_currentScheduleNotExists_expect_throwsNotFoundCoachScheduleException() {
+			UpdateMenteeScheduleRequestDto request = new UpdateMenteeScheduleRequestDto(1L, 2L);
+
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+				.willThrow(NotFoundCoachScheduleException.class);
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					menteeScheduleService.checkIfUpdatePossible(request))
+				.isInstanceOf(NotFoundCoachScheduleException.class);
+		}
+
+		@Test
+		@DisplayName("변경하려는 스케줄 정보가 존재하지 않는다면 NotFoundCoachScheduleException이 발생한다.")
+		void when_newScheduleNotExists_expect_throwsNotFoundCoachScheduleException() {
+			UpdateMenteeScheduleRequestDto request = new UpdateMenteeScheduleRequestDto(1L, 2L);
+
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+				.willThrow(NotFoundCoachScheduleException.class);
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					menteeScheduleService.updateMenteeSchedule(request))
+				.isInstanceOf(NotFoundCoachScheduleException.class);
 		}
 	}
 


### PR DESCRIPTION
### 작업 내용
- 기존 코칭 일정 id와 수정하려는 새로운 코칭 일정 id로 일정을 변경한다.
- 현재 날짜가 기존 코칭 날짜의 하루 전인지 확인한다.
  - ***e.g.*** 기존 코칭 일정이 5시 17일 오후 5시일 때 현재 날짜가 5월 16일이어야 일정 변경이 가능하다.
- `coaching_schedule` 테이블의 `matchYn` 컬럼 값을 기존 일정은 `false`로, 새로운 일정은 `true`로 변경한다.