### PR TITLE
[#21] 멘티 일정 취소 기능을 구현한다.

### DIFF
--- a/src/main/java/cobook/buddywisdom/cancellation/controller/DirectionType.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/controller/DirectionType.java
@@ -1,5 +1,0 @@
-package cobook.buddywisdom.cancellation.controller;
-
-public enum DirectionType {
-	SENT, RECEIVED
-}

--- a/src/main/java/cobook/buddywisdom/cancellation/controller/DirectionType.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/controller/DirectionType.java
@@ -1,0 +1,5 @@
+package cobook.buddywisdom.cancellation.controller;
+
+public enum DirectionType {
+	SENT, RECEIVED
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestController.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestController.java
@@ -1,0 +1,54 @@
+package cobook.buddywisdom.cancellation.controller;
+
+import static cobook.buddywisdom.cancellation.controller.DirectionType.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import cobook.buddywisdom.cancellation.dto.request.CancelRequestDto;
+import cobook.buddywisdom.cancellation.dto.request.ConfirmCancelRequestDto;
+import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
+import cobook.buddywisdom.cancellation.service.CancelRequestService;
+import cobook.buddywisdom.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/mentees/schedule")
+public class MenteeCancelRequestController {
+
+	private final CancelRequestService cancelRequestService;
+
+	public MenteeCancelRequestController(CancelRequestService cancelRequestService) {
+		this.cancelRequestService = cancelRequestService;
+	}
+
+	@GetMapping(value = "/cancel-request/sent")
+	public ResponseEntity<List<CancelRequestResponseDto>> getSentCancelRequest(@AuthenticationPrincipal CustomUserDetails member) {
+		return ResponseEntity.ok(cancelRequestService.getCancelRequest(member.getId(), SENT));
+	}
+
+	@GetMapping(value = "/cancel-request/received")
+	public ResponseEntity<List<CancelRequestResponseDto>> getReceivedCancelRequest(@AuthenticationPrincipal CustomUserDetails member) {
+		return ResponseEntity.ok(cancelRequestService.getCancelRequest(member.getId(), RECEIVED));
+	}
+
+	@PostMapping(value = "/cancel-request")
+	public ResponseEntity<CancelRequestResponseDto> createCancelRequest(@AuthenticationPrincipal CustomUserDetails member,
+													@RequestBody @Valid CancelRequestDto request) {
+		return ResponseEntity.ok(cancelRequestService.saveCancelRequestByMentee(member.getId(), request.menteeScheduleId(), request.reason()));
+	}
+
+	@PatchMapping(value = "/cancel-request")
+	public ResponseEntity<Void> updateCancelRequest(@RequestBody @Valid ConfirmCancelRequestDto request) {
+		cancelRequestService.confirmCancelRequest(request.id(), request.menteeScheduleId());
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestController.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestController.java
@@ -1,6 +1,5 @@
 package cobook.buddywisdom.cancellation.controller;
 
-import static cobook.buddywisdom.cancellation.controller.DirectionType.*;
 
 import java.util.List;
 
@@ -11,12 +10,14 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cobook.buddywisdom.cancellation.dto.request.CancelRequestDto;
 import cobook.buddywisdom.cancellation.dto.request.ConfirmCancelRequestDto;
 import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
 import cobook.buddywisdom.cancellation.service.CancelRequestService;
+import cobook.buddywisdom.cancellation.vo.DirectionType;
 import cobook.buddywisdom.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 
@@ -30,14 +31,10 @@ public class MenteeCancelRequestController {
 		this.cancelRequestService = cancelRequestService;
 	}
 
-	@GetMapping(value = "/cancel-request/sent")
-	public ResponseEntity<List<CancelRequestResponseDto>> getSentCancelRequest(@AuthenticationPrincipal CustomUserDetails member) {
-		return ResponseEntity.ok(cancelRequestService.getCancelRequest(member.getId(), SENT));
-	}
-
-	@GetMapping(value = "/cancel-request/received")
-	public ResponseEntity<List<CancelRequestResponseDto>> getReceivedCancelRequest(@AuthenticationPrincipal CustomUserDetails member) {
-		return ResponseEntity.ok(cancelRequestService.getCancelRequest(member.getId(), RECEIVED));
+	@GetMapping(value = "/cancel-request")
+	public ResponseEntity<List<CancelRequestResponseDto>> getCancelRequestByDirection(@AuthenticationPrincipal CustomUserDetails member,
+																						@RequestParam("direction") DirectionType direction) {
+		return ResponseEntity.ok(cancelRequestService.getCancelRequest(member.getId(), direction));
 	}
 
 	@PostMapping(value = "/cancel-request")

--- a/src/main/java/cobook/buddywisdom/cancellation/domain/CancelRequest.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/domain/CancelRequest.java
@@ -1,0 +1,45 @@
+package cobook.buddywisdom.cancellation.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CancelRequest {
+	private Long id;
+	private Long menteeScheduleId;
+	private Long senderId;
+	private Long receiverId;
+	private String reason;
+	private boolean confirmYn;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public static CancelRequest of(Long id, Long menteeScheduleId, Long senderId, Long receiverId, String reason,
+									boolean confirmYn, LocalDateTime createdAt, LocalDateTime updatedAt) {
+		CancelRequest cancelRequest = new CancelRequest();
+		cancelRequest.id = id;
+		cancelRequest.menteeScheduleId = menteeScheduleId;
+		cancelRequest.senderId = senderId;
+		cancelRequest.receiverId = receiverId;
+		cancelRequest.reason = reason;
+		cancelRequest.confirmYn = confirmYn;
+		cancelRequest.createdAt = createdAt;
+		cancelRequest.updatedAt = updatedAt;
+		return cancelRequest;
+	}
+
+	public static CancelRequest requestOf(Long menteeScheduleId, Long senderId, Long receiverId, String reason) {
+		CancelRequest cancelRequest = new CancelRequest();
+		cancelRequest.menteeScheduleId = menteeScheduleId;
+		cancelRequest.senderId = senderId;
+		cancelRequest.receiverId = receiverId;
+		cancelRequest.reason = reason;
+		return cancelRequest;
+	}
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/dto/request/CancelRequestDto.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/dto/request/CancelRequestDto.java
@@ -1,0 +1,12 @@
+package cobook.buddywisdom.cancellation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CancelRequestDto (
+	@NotNull(message = "취소하려는 일정을 선택해 주세요.")
+	Long menteeScheduleId,
+	@NotBlank(message = "취소 사유를 입력해 주세요.")
+	String reason
+) {
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/dto/request/ConfirmCancelRequestDto.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/dto/request/ConfirmCancelRequestDto.java
@@ -2,8 +2,8 @@ package cobook.buddywisdom.cancellation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record ConfirmCancelRequestDto (
-	@NotNull(message = "확인하려는 요청 정보가 필요합니다.")
+public record ConfirmCancelRequestDto(
+	@NotNull(message = "취소 요청 정보가 필요합니다.")
 	Long id,
 	@NotNull(message = "스케줄 정보가 필요합니다.")
 	Long menteeScheduleId

--- a/src/main/java/cobook/buddywisdom/cancellation/dto/request/ConfirmCancelRequestDto.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/dto/request/ConfirmCancelRequestDto.java
@@ -1,0 +1,11 @@
+package cobook.buddywisdom.cancellation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ConfirmCancelRequestDto (
+	@NotNull(message = "확인하려는 요청 정보가 필요합니다.")
+	Long id,
+	@NotNull(message = "스케줄 정보가 필요합니다.")
+	Long menteeScheduleId
+) {
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/dto/response/CancelRequestResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/dto/response/CancelRequestResponseDto.java
@@ -1,0 +1,29 @@
+package cobook.buddywisdom.cancellation.dto.response;
+
+import java.time.LocalDateTime;
+
+import cobook.buddywisdom.cancellation.domain.CancelRequest;
+
+public record CancelRequestResponseDto (
+	long id,
+	long menteeScheduleId,
+	long senderId,
+	long receiverId,
+	String reason,
+	boolean confirmYn,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+	public static CancelRequestResponseDto from(CancelRequest cancelRequest) {
+		return new CancelRequestResponseDto(
+			cancelRequest.getId(),
+			cancelRequest.getMenteeScheduleId(),
+			cancelRequest.getSenderId(),
+			cancelRequest.getReceiverId(),
+			cancelRequest.getReason(),
+			cancelRequest.isConfirmYn(),
+			cancelRequest.getCreatedAt(),
+			cancelRequest.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/exception/ConfirmedCancelRequestException.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/exception/ConfirmedCancelRequestException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.cancellation.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class ConfirmedCancelRequestException extends RuntimeException {
+	public ConfirmedCancelRequestException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/exception/NotFoundCancelRequestException.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/exception/NotFoundCancelRequestException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.cancellation.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class NotFoundCancelRequestException extends RuntimeException {
+	public NotFoundCancelRequestException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/mapper/CancelRequestMapper.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/mapper/CancelRequestMapper.java
@@ -1,0 +1,17 @@
+package cobook.buddywisdom.cancellation.mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import cobook.buddywisdom.cancellation.domain.CancelRequest;
+
+@Mapper
+public interface CancelRequestMapper {
+	Optional<CancelRequest> findById(long id);
+	List<CancelRequest> findBySenderId(long senderId);
+	List<CancelRequest> findByReceiverId(long receiverId);
+	void save(CancelRequest cancelRequest);
+	void updateConfirmYn(long id, boolean confirmYn);
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/service/CancelRequestService.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/service/CancelRequestService.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import cobook.buddywisdom.cancellation.controller.DirectionType;
+import cobook.buddywisdom.cancellation.vo.DirectionType;
 import cobook.buddywisdom.cancellation.domain.CancelRequest;
 import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
 import cobook.buddywisdom.cancellation.exception.ConfirmedCancelRequestException;
@@ -38,8 +38,7 @@ public class CancelRequestService {
 
 		if (direction.equals(DirectionType.SENT)) {
 			cancelRequestList = cancelRequestMapper.findBySenderId(memberId);
-		}
-		if (direction.equals(DirectionType.RECEIVED)) {
+		} else if (direction.equals(DirectionType.RECEIVED)) {
 			cancelRequestList = cancelRequestMapper.findByReceiverId(memberId);
 		}
 

--- a/src/main/java/cobook/buddywisdom/cancellation/service/CancelRequestService.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/service/CancelRequestService.java
@@ -1,0 +1,78 @@
+package cobook.buddywisdom.cancellation.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import cobook.buddywisdom.cancellation.controller.DirectionType;
+import cobook.buddywisdom.cancellation.domain.CancelRequest;
+import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
+import cobook.buddywisdom.cancellation.exception.ConfirmedCancelRequestException;
+import cobook.buddywisdom.cancellation.exception.NotFoundCancelRequestException;
+import cobook.buddywisdom.cancellation.mapper.CancelRequestMapper;
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+import cobook.buddywisdom.coach.service.CoachScheduleService;
+import cobook.buddywisdom.global.exception.ErrorMessage;
+import cobook.buddywisdom.mentee.service.MenteeScheduleService;
+
+@Service
+@Transactional(readOnly = true)
+public class CancelRequestService {
+	private final CancelRequestMapper cancelRequestMapper;
+	private final CoachScheduleService coachScheduleService;
+	private final MenteeScheduleService menteeScheduleService;
+
+	public CancelRequestService(CancelRequestMapper cancelRequestMapper, CoachScheduleService coachScheduleService,
+		MenteeScheduleService menteeScheduleService) {
+		this.cancelRequestMapper = cancelRequestMapper;
+		this.coachScheduleService = coachScheduleService;
+		this.menteeScheduleService = menteeScheduleService;
+	}
+
+	public List<CancelRequestResponseDto> getCancelRequest(long memberId, DirectionType direction) {
+		List<CancelRequest> cancelRequestList = new ArrayList<>();
+
+		if (direction.equals(DirectionType.SENT)) {
+			cancelRequestList = cancelRequestMapper.findBySenderId(memberId);
+		}
+		if (direction.equals(DirectionType.RECEIVED)) {
+			cancelRequestList = cancelRequestMapper.findByReceiverId(memberId);
+		}
+
+		return Optional.ofNullable(cancelRequestList)
+			.stream()
+			.flatMap(List::stream)
+			.map(CancelRequestResponseDto::from)
+			.collect(Collectors.toUnmodifiableList());
+	}
+
+	@Transactional
+	public CancelRequestResponseDto saveCancelRequestByMentee(long menteeId, long menteeScheduleId, String reason) {
+		menteeScheduleService.getMenteeSchedule(menteeId, menteeScheduleId);
+
+		CoachSchedule coachSchedule = coachScheduleService.getCoachSchedule(menteeScheduleId, true);
+
+		CancelRequest cancelRequest = CancelRequest.requestOf(menteeScheduleId, menteeId, coachSchedule.getCoachId(), reason);
+		cancelRequestMapper.save(cancelRequest);
+
+		return CancelRequestResponseDto.from(cancelRequest);
+	}
+
+	@Transactional
+	public void confirmCancelRequest(long cancelRequestId, long menteeScheduleId) {
+		CancelRequest cancelRequest = cancelRequestMapper.findById(cancelRequestId)
+			.orElseThrow(() -> new NotFoundCancelRequestException(ErrorMessage.NOT_FOUND_CANCEL_REQUEST));
+
+		if (cancelRequest.isConfirmYn()) {
+			throw new ConfirmedCancelRequestException(ErrorMessage.CONFIRMED_CANCEL_REQUEST);
+		}
+
+		cancelRequestMapper.updateConfirmYn(cancelRequestId, true);
+
+		menteeScheduleService.deleteMenteeSchedule(menteeScheduleId);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/cancellation/vo/DirectionType.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/vo/DirectionType.java
@@ -1,0 +1,5 @@
+package cobook.buddywisdom.cancellation.vo;
+
+public enum DirectionType {
+	SENT, RECEIVED
+}

--- a/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import cobook.buddywisdom.cancellation.exception.ConfirmedCancelRequestException;
+import cobook.buddywisdom.cancellation.exception.NotFoundCancelRequestException;
 import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
 import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotAllowedUpdateException;
@@ -59,5 +61,17 @@ public class ApiExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleNotAllowedUpdateException(NotAllowedUpdateException exception) {
 		log.error("NotAllowedUpdateException : ", exception);
 		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_ALLOWED_UPDATE_SCHEDULE);
+	}
+
+	@ExceptionHandler(NotFoundCancelRequestException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundCancelRequestException(NotFoundCancelRequestException exception) {
+		log.error("NotFoundCancelRequestException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_CANCEL_REQUEST);
+	}
+
+	@ExceptionHandler(ConfirmedCancelRequestException.class)
+	public ResponseEntity<ErrorResponse> handleConfirmedCancelRequestException(ConfirmedCancelRequestException exception) {
+		log.error("ConfirmedCancelRequestException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.CONFIRMED_CANCEL_REQUEST);
 	}
 }

--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -20,8 +20,11 @@ public enum ErrorMessage {
 	NOT_FOUND_COACH_SCHEDULE(HttpStatus.NOT_FOUND, "이미 신청이 마감되었거나 존재하지 않는 스케줄입니다."),
 
 	// RELATIONSHIP
-	NOT_FOUND_COACHING_RELATIONSHIP(HttpStatus.NOT_FOUND, "매칭된 코칭 팀이 존재하지 않습니다.")
+	NOT_FOUND_COACHING_RELATIONSHIP(HttpStatus.NOT_FOUND, "매칭된 코칭 팀이 존재하지 않습니다."),
 
+	// CANCEL_REQUEST
+	NOT_FOUND_CANCEL_REQUEST(HttpStatus.NOT_FOUND, "등록된 일정 취소 요청이 존재하지 않습니다."),
+	CONFIRMED_CANCEL_REQUEST(HttpStatus.BAD_REQUEST, "이미 확인이 완료된 취소 요청입니다.")
 	;
 
 	private HttpStatus status;

--- a/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
+++ b/src/main/java/cobook/buddywisdom/mentee/mapper/MenteeScheduleMapper.java
@@ -13,8 +13,10 @@ import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
 @Mapper
 public interface MenteeScheduleMapper {
 	List<MenteeMonthlySchedule> findAllByMenteeIdAndPossibleDateTime(long menteeId, LocalDateTime startDateTime, LocalDateTime endDateTime);
-	Optional<MenteeScheduleFeedback> findByMenteeIdAndCoachingScheduleId(long menteeId, long coachingScheduleId);
+	Optional<MenteeScheduleFeedback> findWithFeedbackByMenteeIdAndCoachingScheduleId(long menteeId, long coachingScheduleId);
 	Optional<MenteeSchedule> findByCoachingScheduleId(long coachingScheduleId);
+	Optional<MenteeSchedule> findByMenteeIdAndCoachingScheduleId(long menteeId, long coachingScheduleId);
 	void save(MenteeSchedule menteeSchedule);
 	void updateCoachingScheduleId(long currentCoachingId, long newCoachingId);
+	void deleteByCoachingScheduleId(long coachingScheduleId);
 }

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -56,10 +56,15 @@ public class MenteeScheduleService {
 	}
 
 	public MenteeScheduleFeedbackResponseDto getMenteeScheduleFeedback(long menteeId, long coachingScheduleId) {
-		MenteeScheduleFeedback menteeScheduleFeedback = menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(menteeId, coachingScheduleId)
+		MenteeScheduleFeedback menteeScheduleFeedback = menteeScheduleMapper.findWithFeedbackByMenteeIdAndCoachingScheduleId(menteeId, coachingScheduleId)
 			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
 
 		return MenteeScheduleFeedbackResponseDto.from(menteeScheduleFeedback);
+	}
+
+	public MenteeSchedule getMenteeSchedule(long menteeId, long coachingScheduleId) {
+		return menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(menteeId, coachingScheduleId)
+			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
 	}
 
 	public List<MyCoachScheduleResponseDto> getMyCoachSchedule(long menteeId) {
@@ -124,5 +129,13 @@ public class MenteeScheduleService {
 		if (!LocalDate.now().isBefore(date)) {
 			throw new NotAllowedUpdateException(ErrorMessage.NOT_ALLOWED_UPDATE_SCHEDULE);
 		}
+	}
+
+	@Transactional
+	public void deleteMenteeSchedule(long menteeScheduleId) {
+		MenteeSchedule menteeSchedule = menteeScheduleMapper.findByCoachingScheduleId(menteeScheduleId)
+			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
+
+		menteeScheduleMapper.deleteByCoachingScheduleId(menteeSchedule.getCoachingScheduleId());
 	}
 }

--- a/src/main/resources/mapper/cancellation/CancelRequestMapper.xml
+++ b/src/main/resources/mapper/cancellation/CancelRequestMapper.xml
@@ -39,7 +39,7 @@
         ORDER BY id DESC
     </select>
 
-    <insert id="save" parameterType="CancelRequest" useGeneratedKeys="true" keyProperty="id">
+    <insert id="save" parameterType="CancelRequest">
         INSERT INTO cancel_request(
                                    mentee_schedule_id,
                                    sender_id,
@@ -66,8 +66,8 @@
 
     <update id="updateConfirmYn" parameterType="map">
         UPDATE cancel_request
-        SET confirm_yn = #{confirmYn}
-            AND updated_at = NOW()
+        SET confirm_yn = #{confirmYn},
+            updated_at = NOW()
         WHERE id = #{id}
     </update>
 

--- a/src/main/resources/mapper/cancellation/CancelRequestMapper.xml
+++ b/src/main/resources/mapper/cancellation/CancelRequestMapper.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="cobook.buddywisdom.cancellation.mapper.CancelRequestMapper">
+
+    <sql id="cancelRequestColumns">
+        id,
+        mentee_schedule_id,
+        sender_id,
+        receiver_id,
+        reason,
+        confirm_yn,
+        created_at,
+        updated_at
+    </sql>
+
+    <select id="findById" parameterType="map" resultType="CancelRequest">
+        SELECT
+            <include refid="cancelRequestColumns"></include>
+        FROM cancel_request
+        WHERE id = #{id}
+    </select>
+
+    <select id="findBySenderId" parameterType="long" resultType="CancelRequest">
+        SELECT
+            <include refid="cancelRequestColumns"></include>
+        FROM cancel_request
+        WHERE sender_id = #{senderId}
+        ORDER BY id DESC
+    </select>
+
+    <select id="findByReceiverId" parameterType="long" resultType="CancelRequest">
+        SELECT
+            <include refid="cancelRequestColumns"></include>
+        FROM cancel_request
+        WHERE receiver_id = #{receiverId}
+        ORDER BY id DESC
+    </select>
+
+    <insert id="save" parameterType="CancelRequest" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO cancel_request(
+                                   mentee_schedule_id,
+                                   sender_id,
+                                   receiver_id,
+                                   reason,
+                                   created_at,
+                                   updated_at)
+        VALUES (
+                #{menteeScheduleId},
+                #{senderId},
+                #{receiverId},
+                #{reason},
+                NOW(),
+                NOW()
+                )
+        <selectKey keyProperty="id,createdAt,updatedAt" resultType="CancelRequest" order="AFTER">
+            SELECT id,
+                   created_at,
+                   updated_at
+            FROM cancel_request
+            WHERE mentee_schedule_id = #{menteeScheduleId}
+        </selectKey>
+    </insert>
+
+    <update id="updateConfirmYn" parameterType="map">
+        UPDATE cancel_request
+        SET confirm_yn = #{confirmYn}
+            AND updated_at = NOW()
+        WHERE id = #{id}
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
+++ b/src/main/resources/mapper/mentee/MenteeScheduleMapper.xml
@@ -5,6 +5,11 @@
 
 <mapper namespace="cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper">
 
+    <sql id="menteeScheduleColumns">
+        coaching_schedule_id,
+        mentee_id
+    </sql>
+
     <select id="findAllByMenteeIdAndPossibleDateTime" parameterType="map" resultType="MenteeMonthlySchedule">
         SELECT ms.coaching_schedule_id,
                cs.possible_date_time
@@ -15,7 +20,7 @@
             AND cs.possible_date_time BETWEEN #{startDateTime} AND #{endDateTime}
     </select>
 
-    <select id="findByMenteeIdAndCoachingScheduleId" parameterType="map" resultType="MenteeScheduleFeedback">
+    <select id="findWithFeedbackByMenteeIdAndCoachingScheduleId" parameterType="map" resultType="MenteeScheduleFeedback">
         SELECT ms.coaching_schedule_id,
                cs.possible_date_time,
                fb.id AS feedback_id,
@@ -30,9 +35,17 @@
             AND ms.coaching_schedule_id = #{coachingScheduleId}
     </select>
 
+    <select id="findByMenteeIdAndCoachingScheduleId" parameterType="map" resultType="MenteeSchedule">
+        SELECT
+            <include refid="menteeScheduleColumns"></include>
+        FROM mentee_schedule
+        WHERE mentee_id = #{menteeId}
+          AND coaching_schedule_id = #{coachingScheduleId}
+    </select>
+
     <select id="findByCoachingScheduleId" parameterType="map" resultType="MenteeSchedule">
-        SELECT coaching_schedule_id,
-               mentee_id
+        SELECT
+            <include refid="menteeScheduleColumns"></include>
         FROM mentee_schedule
         WHERE coaching_schedule_id = #{coachingScheduleId}
     </select>
@@ -47,5 +60,10 @@
         SET coaching_schedule_id = #{newCoachingId}
         WHERE coaching_schedule_id = #{currentCoachingId}
     </update>
+
+    <delete id="deleteByCoachingScheduleId" parameterType="long">
+        DELETE FROM mentee_schedule
+        WHERE coaching_schedule_id = #{coachingScheduleId}
+    </delete>
 
 </mapper>

--- a/src/test/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestControllerTest.java
@@ -1,0 +1,184 @@
+package cobook.buddywisdom.cancellation.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.BDDMockito;
+import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cobook.buddywisdom.cancellation.dto.request.CancelRequestDto;
+import cobook.buddywisdom.cancellation.dto.request.ConfirmCancelRequestDto;
+import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
+import cobook.buddywisdom.cancellation.service.CancelRequestService;
+import cobook.buddywisdom.util.WithMockCustomUser;
+
+@AutoConfigureMybatis
+@WebMvcTest(MenteeCancelRequestController.class)
+public class MenteeCancelRequestControllerTest {
+
+	@MockBean
+	private CancelRequestService cancelRequestService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private final static String BASE_URL = "/api/v1/mentees/schedule";
+
+	private static CancelRequestResponseDto cancelRequestResponseDto;
+
+	@BeforeAll
+	static void setUp() {
+		cancelRequestResponseDto =
+			new CancelRequestResponseDto(1, 1, 4, 3,
+				"취소 사유", false, LocalDateTime.now(), LocalDateTime.now());
+	}
+
+	@Nested
+	@DisplayName("코칭 취소 요청 내역 조회")
+	@WithMockCustomUser(role = "MENTEE")
+	class CancelRequestTest {
+		@Test
+		@DisplayName("인증된 멘티의 보낸 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
+		void when_authenticatedMenteeExistsAndDirectionTypeIsSent_expect_callMethodAndReturn200Ok() throws Exception {
+			BDDMockito
+				.given(cancelRequestService.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.SENT)))
+				.willReturn(List.of(cancelRequestResponseDto));
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.get(BASE_URL + "/cancel-request/sent"))
+				.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(cancelRequestService)
+				.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.SENT));
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+
+		}
+
+		@Test
+		@DisplayName("인증된 멘티의 받은 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
+		void when_authenticatedMenteeExistsAndDirectionTypeIsReceived_expect_callMethodAndReturn200Ok() throws Exception {
+			BDDMockito
+				.given(cancelRequestService.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.RECEIVED)))
+				.willReturn(List.of(cancelRequestResponseDto));
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.get(BASE_URL + "/cancel-request/received"))
+					.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(cancelRequestService)
+				.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.RECEIVED));
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 취소 요청")
+	@WithMockCustomUser(role = "MENTEE")
+	class CreateCancelRequestTest {
+		@Test
+		@DisplayName("유효한 취소 일정 정보와 사유가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_scheduleIdAndReasonOfCancelAreValid_expects_callMethodAndReturn200Ok() throws Exception {
+			CancelRequestDto cancelRequestDto = new CancelRequestDto(1L, "취소 사유");
+
+			BDDMockito
+				.given(cancelRequestService.saveCancelRequestByMentee(BDDMockito.anyLong(), BDDMockito.anyLong(), BDDMockito.anyString()))
+				.willReturn(cancelRequestResponseDto);
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.post(BASE_URL + "/cancel-request")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(cancelRequestDto))
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(cancelRequestService)
+				.saveCancelRequestByMentee(BDDMockito.anyLong(), BDDMockito.anyLong(), BDDMockito.anyString());
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@DisplayName("취소 일정 정보와 사유가 null 값이라면 400 Bad Request가 반환된다.")
+		void when_scheduleIdAndReasonOfCancelAreNull_expects_return400BadRequest(String reason) throws Exception {
+			CancelRequestDto cancelRequestDto = new CancelRequestDto(null, reason);
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.post(BASE_URL + "/cancel-request")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(cancelRequestDto))
+							.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 취소 요청 확인")
+	@WithMockCustomUser(role = "MENTEE")
+	class UpdateCancelRequestTest {
+		@Test
+		@DisplayName("유효한 취소 요청 및 일정 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_requestIdsArdValid_expects_callMethodAndReturns200Ok() throws Exception {
+			ConfirmCancelRequestDto confirmCancelRequestDto =
+				new ConfirmCancelRequestDto(1L, 1L);
+
+			BDDMockito.willDoNothing()
+				.given(cancelRequestService).confirmCancelRequest(BDDMockito.anyLong(), BDDMockito.anyLong());
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.patch(BASE_URL + "/cancel-request")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(confirmCancelRequestDto))
+							.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(cancelRequestService)
+				.confirmCancelRequest(BDDMockito.anyLong(), BDDMockito.anyLong());
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@Test
+		@DisplayName("취소 요청 및 일정 정보가 null 값이라면 400 Bad Request가 반환된다.")
+		void when_requestIdsArdNull_expects_return400BadRequest() throws Exception {
+			ConfirmCancelRequestDto confirmCancelRequestDto =
+				new ConfirmCancelRequestDto(null, null);
+
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.patch(BASE_URL + "/cancel-request")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(confirmCancelRequestDto))
+							.with(SecurityMockMvcRequestPostProcessors.csrf()))
+					.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+	}
+}

--- a/src/test/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestControllerTest.java
@@ -1,5 +1,7 @@
 package cobook.buddywisdom.cancellation.controller;
 
+import static org.mockito.ArgumentMatchers.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,6 +30,7 @@ import cobook.buddywisdom.cancellation.dto.request.CancelRequestDto;
 import cobook.buddywisdom.cancellation.dto.request.ConfirmCancelRequestDto;
 import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
 import cobook.buddywisdom.cancellation.service.CancelRequestService;
+import cobook.buddywisdom.cancellation.vo.DirectionType;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
 @AutoConfigureMybatis
@@ -62,16 +65,17 @@ public class MenteeCancelRequestControllerTest {
 		@DisplayName("인증된 멘티의 보낸 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
 		void when_authenticatedMenteeExistsAndDirectionTypeIsSent_expect_callMethodAndReturn200Ok() throws Exception {
 			BDDMockito
-				.given(cancelRequestService.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.SENT)))
+				.given(cancelRequestService.getCancelRequest(anyLong(), eq(DirectionType.SENT)))
 				.willReturn(List.of(cancelRequestResponseDto));
 
 			ResultActions response =
 				mockMvc.perform(
-					MockMvcRequestBuilders.get(BASE_URL + "/cancel-request/sent"))
+					MockMvcRequestBuilders.get(BASE_URL + "/cancel-request")
+						.param("direction", String.valueOf(DirectionType.SENT)))
 				.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(cancelRequestService)
-				.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.SENT));
+				.getCancelRequest(anyLong(), eq(DirectionType.SENT));
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 
 		}
@@ -80,16 +84,17 @@ public class MenteeCancelRequestControllerTest {
 		@DisplayName("인증된 멘티의 받은 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
 		void when_authenticatedMenteeExistsAndDirectionTypeIsReceived_expect_callMethodAndReturn200Ok() throws Exception {
 			BDDMockito
-				.given(cancelRequestService.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.RECEIVED)))
+				.given(cancelRequestService.getCancelRequest(anyLong(), eq(DirectionType.RECEIVED)))
 				.willReturn(List.of(cancelRequestResponseDto));
 
 			ResultActions response =
 				mockMvc.perform(
-						MockMvcRequestBuilders.get(BASE_URL + "/cancel-request/received"))
+						MockMvcRequestBuilders.get(BASE_URL + "/cancel-request")
+							.param("direction", String.valueOf(DirectionType.RECEIVED)))
 					.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(cancelRequestService)
-				.getCancelRequest(BDDMockito.anyLong(), BDDMockito.eq(DirectionType.RECEIVED));
+				.getCancelRequest(anyLong(), eq(DirectionType.RECEIVED));
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 	}
@@ -104,7 +109,7 @@ public class MenteeCancelRequestControllerTest {
 			CancelRequestDto cancelRequestDto = new CancelRequestDto(1L, "취소 사유");
 
 			BDDMockito
-				.given(cancelRequestService.saveCancelRequestByMentee(BDDMockito.anyLong(), BDDMockito.anyLong(), BDDMockito.anyString()))
+				.given(cancelRequestService.saveCancelRequestByMentee(anyLong(), anyLong(), anyString()))
 				.willReturn(cancelRequestResponseDto);
 
 			ResultActions response =
@@ -116,7 +121,7 @@ public class MenteeCancelRequestControllerTest {
 					.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(cancelRequestService)
-				.saveCancelRequestByMentee(BDDMockito.anyLong(), BDDMockito.anyLong(), BDDMockito.anyString());
+				.saveCancelRequestByMentee(anyLong(), anyLong(), anyString());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 
@@ -149,7 +154,7 @@ public class MenteeCancelRequestControllerTest {
 				new ConfirmCancelRequestDto(1L, 1L);
 
 			BDDMockito.willDoNothing()
-				.given(cancelRequestService).confirmCancelRequest(BDDMockito.anyLong(), BDDMockito.anyLong());
+				.given(cancelRequestService).confirmCancelRequest(anyLong(), anyLong());
 
 			ResultActions response =
 				mockMvc.perform(
@@ -160,7 +165,7 @@ public class MenteeCancelRequestControllerTest {
 					.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(cancelRequestService)
-				.confirmCancelRequest(BDDMockito.anyLong(), BDDMockito.anyLong());
+				.confirmCancelRequest(anyLong(), anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 

--- a/src/test/java/cobook/buddywisdom/cancellation/service/CancelRequestServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/service/CancelRequestServiceTest.java
@@ -1,6 +1,7 @@
 package cobook.buddywisdom.cancellation.service;
 
-import static cobook.buddywisdom.cancellation.controller.DirectionType.*;
+import static cobook.buddywisdom.cancellation.vo.DirectionType.*;
+import static org.mockito.ArgumentMatchers.*;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -61,7 +62,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("보낸 취소 요청 내역이 존재하면 취소 요청 정보를 반환한다.")
 		void when_sentRequestsExist_expect_returnResponseList() {
-			BDDMockito.given(cancelRequestMapper.findBySenderId(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findBySenderId(anyLong()))
 				.willReturn(List.of(cancelRequest));
 
 			List<CancelRequestResponseDto> expectedResponse =
@@ -80,7 +81,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("보낸 취소 요청 내역이 존재하지 않으면 빈 배열을 반환한다.")
 		void when_sentRequestsNotExist_expect_returnEmptyArray() {
-			BDDMockito.given(cancelRequestMapper.findBySenderId(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findBySenderId(anyLong()))
 				.willReturn(Collections.emptyList());
 
 			List<CancelRequestResponseDto> expectedResponse =
@@ -93,7 +94,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("받은 취소 요청 내역이 존재하면 취소 요청 정보를 반환한다.")
 		void when_receivedRequestsExist_expect_returnResponseList() {
-			BDDMockito.given(cancelRequestMapper.findByReceiverId(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findByReceiverId(anyLong()))
 				.willReturn(List.of(cancelRequest));
 
 			List<CancelRequestResponseDto> expectedResponse =
@@ -112,7 +113,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("받은 취소 요청 내역이 존재하지 않으면 빈 배열을 반환한다.")
 		void when_receivedRequestsNotExist_expect_returnEmptyArray() {
-			BDDMockito.given(cancelRequestMapper.findByReceiverId(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findByReceiverId(anyLong()))
 				.willReturn(Collections.emptyList());
 
 			List<CancelRequestResponseDto> expectedResponse =
@@ -132,9 +133,9 @@ public class CancelRequestServiceTest {
 			MenteeSchedule menteeSchedule = MenteeSchedule.of(1L, 4L);
 			CoachSchedule coachSchedule = CoachSchedule.of(1L, 3L, LocalDateTime.now(), false);
 
-			BDDMockito.given(menteeScheduleService.getMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong()))
+			BDDMockito.given(menteeScheduleService.getMenteeSchedule(anyLong(), anyLong()))
 				.willReturn(menteeSchedule);
-			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+			BDDMockito.given(coachScheduleService.getCoachSchedule(anyLong(), anyBoolean()))
 				.willReturn(coachSchedule);
 			BDDMockito.doAnswer(invocation -> {
 				CancelRequest savedCancelRequest = invocation.getArgument(0);
@@ -153,7 +154,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("해당하는 멘티 스케줄이 존재하지 않으면 NotFoundMenteeScheduleException이 발생한다.")
 		void when_menteeScheduleDoesNotExists_expect_throwsNotFoundMenteeScheduleException() {
-			BDDMockito.given(menteeScheduleService.getMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong()))
+			BDDMockito.given(menteeScheduleService.getMenteeSchedule(anyLong(), anyLong()))
 				.willThrow(NotFoundMenteeScheduleException.class);
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->
@@ -164,7 +165,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("해당하는 코칭 스케줄이 존재하지 않으면 NotFoundCoachScheduleException이 발생한다.")
 		void when_coachScheduleNotExists_expect_throwsNotFoundCoachScheduleException() {
-			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+			BDDMockito.given(coachScheduleService.getCoachSchedule(anyLong(), anyBoolean()))
 				.willThrow(NotFoundCoachScheduleException.class);
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->
@@ -179,12 +180,12 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("취소 요청 및 일정 정보가 전달되면 상태 값을 변경하고 해당 스케줄을 삭제한다.")
 		void when_requestIdsArdValid_expect_updateConfirmYnAndDeleteSchedule() {
-			BDDMockito.given(cancelRequestMapper.findById(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findById(anyLong()))
 				.willReturn(Optional.ofNullable(cancelRequest));
 			BDDMockito.willDoNothing().
-				given(cancelRequestMapper).updateConfirmYn(BDDMockito.anyLong(), BDDMockito.anyBoolean());
+				given(cancelRequestMapper).updateConfirmYn(anyLong(), anyBoolean());
 			BDDMockito.willDoNothing()
-				.given(menteeScheduleService).deleteMenteeSchedule(BDDMockito.anyLong());
+				.given(menteeScheduleService).deleteMenteeSchedule(anyLong());
 
 			cancelRequestService.confirmCancelRequest(1L, 1L);
 
@@ -196,7 +197,7 @@ public class CancelRequestServiceTest {
 		@Test
 		@DisplayName("취소 요청 내역이 존재하지 않으면 NotFoundCancelRequestException이 발생한다.")
 		void when_cancelRequestNotExists_expect_throwsNotFoundCancelRequestException() {
-			BDDMockito.given(cancelRequestMapper.findById(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findById(anyLong()))
 				.willReturn(Optional.empty());
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->
@@ -210,7 +211,7 @@ public class CancelRequestServiceTest {
 			CancelRequest confirmedRequest = CancelRequest.of(1L, 1L, 4L, 3L,
 				"취소 사유", true, LocalDateTime.now(), LocalDateTime.now());
 
-			BDDMockito.given(cancelRequestMapper.findById(BDDMockito.anyLong()))
+			BDDMockito.given(cancelRequestMapper.findById(anyLong()))
 				.willReturn(Optional.of(confirmedRequest));
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->

--- a/src/test/java/cobook/buddywisdom/cancellation/service/CancelRequestServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/service/CancelRequestServiceTest.java
@@ -1,0 +1,221 @@
+package cobook.buddywisdom.cancellation.service;
+
+import static cobook.buddywisdom.cancellation.controller.DirectionType.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.BeanUtils;
+
+import cobook.buddywisdom.cancellation.domain.CancelRequest;
+import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
+import cobook.buddywisdom.cancellation.exception.ConfirmedCancelRequestException;
+import cobook.buddywisdom.cancellation.exception.NotFoundCancelRequestException;
+import cobook.buddywisdom.cancellation.mapper.CancelRequestMapper;
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
+import cobook.buddywisdom.coach.service.CoachScheduleService;
+import cobook.buddywisdom.mentee.domain.MenteeSchedule;
+import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
+import cobook.buddywisdom.mentee.service.MenteeScheduleService;
+
+@ExtendWith(MockitoExtension.class)
+public class CancelRequestServiceTest {
+
+	@Mock
+	CancelRequestMapper cancelRequestMapper;
+
+	@Mock
+	MenteeScheduleService menteeScheduleService;
+
+	@Mock
+	CoachScheduleService coachScheduleService;
+
+	@InjectMocks
+	CancelRequestService cancelRequestService;
+
+	private static CancelRequest cancelRequest;
+
+	@BeforeAll
+	static void setUp() {
+		cancelRequest = CancelRequest.of(1L, 1L, 4L, 3L,
+				"취소 사유", false, LocalDateTime.now(), LocalDateTime.now());
+	}
+
+	@Nested
+	@DisplayName("코칭 취소 요청 내역 조회")
+	class CancelRequestTest {
+		@Test
+		@DisplayName("보낸 취소 요청 내역이 존재하면 취소 요청 정보를 반환한다.")
+		void when_sentRequestsExist_expect_returnResponseList() {
+			BDDMockito.given(cancelRequestMapper.findBySenderId(BDDMockito.anyLong()))
+				.willReturn(List.of(cancelRequest));
+
+			List<CancelRequestResponseDto> expectedResponse =
+				cancelRequestService.getCancelRequest(4L, SENT);
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertEquals(1, expectedResponse.size());
+
+			CancelRequestResponseDto returnedDto = expectedResponse.get(0);
+			Assertions.assertEquals(cancelRequest.getMenteeScheduleId(), returnedDto.menteeScheduleId());
+			Assertions.assertEquals(cancelRequest.getSenderId(), returnedDto.senderId());
+			Assertions.assertEquals(cancelRequest.getReceiverId(), returnedDto.receiverId());
+			Assertions.assertEquals(cancelRequest.getReason(), returnedDto.reason());
+		}
+
+		@Test
+		@DisplayName("보낸 취소 요청 내역이 존재하지 않으면 빈 배열을 반환한다.")
+		void when_sentRequestsNotExist_expect_returnEmptyArray() {
+			BDDMockito.given(cancelRequestMapper.findBySenderId(BDDMockito.anyLong()))
+				.willReturn(Collections.emptyList());
+
+			List<CancelRequestResponseDto> expectedResponse =
+				cancelRequestService.getCancelRequest(4L, SENT);
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertTrue(expectedResponse.isEmpty());
+		}
+
+		@Test
+		@DisplayName("받은 취소 요청 내역이 존재하면 취소 요청 정보를 반환한다.")
+		void when_receivedRequestsExist_expect_returnResponseList() {
+			BDDMockito.given(cancelRequestMapper.findByReceiverId(BDDMockito.anyLong()))
+				.willReturn(List.of(cancelRequest));
+
+			List<CancelRequestResponseDto> expectedResponse =
+				cancelRequestService.getCancelRequest(4L, RECEIVED);
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertEquals(1, expectedResponse.size());
+
+			CancelRequestResponseDto returnedDto = expectedResponse.get(0);
+			Assertions.assertEquals(cancelRequest.getMenteeScheduleId(), returnedDto.menteeScheduleId());
+			Assertions.assertEquals(cancelRequest.getSenderId(), returnedDto.senderId());
+			Assertions.assertEquals(cancelRequest.getReceiverId(), returnedDto.receiverId());
+			Assertions.assertEquals(cancelRequest.getReason(), returnedDto.reason());
+		}
+
+		@Test
+		@DisplayName("받은 취소 요청 내역이 존재하지 않으면 빈 배열을 반환한다.")
+		void when_receivedRequestsNotExist_expect_returnEmptyArray() {
+			BDDMockito.given(cancelRequestMapper.findByReceiverId(BDDMockito.anyLong()))
+				.willReturn(Collections.emptyList());
+
+			List<CancelRequestResponseDto> expectedResponse =
+				cancelRequestService.getCancelRequest(4L, RECEIVED);
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertTrue(expectedResponse.isEmpty());
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 취소 요청")
+	class CreateCancelRequestTest {
+		@Test
+		@DisplayName("유효한 정보가 전달되면 요청이 완료되고 취소 요청 정보를 반환한다.")
+		void when_allInformationIsValid_expect_returnResponse() {
+			MenteeSchedule menteeSchedule = MenteeSchedule.of(1L, 4L);
+			CoachSchedule coachSchedule = CoachSchedule.of(1L, 3L, LocalDateTime.now(), false);
+
+			BDDMockito.given(menteeScheduleService.getMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong()))
+				.willReturn(menteeSchedule);
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+				.willReturn(coachSchedule);
+			BDDMockito.doAnswer(invocation -> {
+				CancelRequest savedCancelRequest = invocation.getArgument(0);
+				BeanUtils.copyProperties(cancelRequest, savedCancelRequest);
+				return null;
+			}).when(cancelRequestMapper).save(BDDMockito.any(CancelRequest.class));
+
+
+			CancelRequestResponseDto expectedResponse =
+				cancelRequestService.saveCancelRequestByMentee(3L, 1L, "취소 사유");
+
+			Assertions.assertNotNull(expectedResponse);
+			Assertions.assertEquals(cancelRequest.getId(), expectedResponse.menteeScheduleId());
+		}
+
+		@Test
+		@DisplayName("해당하는 멘티 스케줄이 존재하지 않으면 NotFoundMenteeScheduleException이 발생한다.")
+		void when_menteeScheduleDoesNotExists_expect_throwsNotFoundMenteeScheduleException() {
+			BDDMockito.given(menteeScheduleService.getMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong()))
+				.willThrow(NotFoundMenteeScheduleException.class);
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					cancelRequestService.saveCancelRequestByMentee(4L, 1L, "취소 사유"))
+				.isInstanceOf(NotFoundMenteeScheduleException.class);
+		}
+
+		@Test
+		@DisplayName("해당하는 코칭 스케줄이 존재하지 않으면 NotFoundCoachScheduleException이 발생한다.")
+		void when_coachScheduleNotExists_expect_throwsNotFoundCoachScheduleException() {
+			BDDMockito.given(coachScheduleService.getCoachSchedule(BDDMockito.anyLong(), BDDMockito.anyBoolean()))
+				.willThrow(NotFoundCoachScheduleException.class);
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					cancelRequestService.saveCancelRequestByMentee(4L, 1L, "취소 사유"))
+				.isInstanceOf(NotFoundCoachScheduleException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 취소 요청 확인")
+	class UpdateCancelRequestTest {
+		@Test
+		@DisplayName("취소 요청 및 일정 정보가 전달되면 상태 값을 변경하고 해당 스케줄을 삭제한다.")
+		void when_requestIdsArdValid_expect_updateConfirmYnAndDeleteSchedule() {
+			BDDMockito.given(cancelRequestMapper.findById(BDDMockito.anyLong()))
+				.willReturn(Optional.ofNullable(cancelRequest));
+			BDDMockito.willDoNothing().
+				given(cancelRequestMapper).updateConfirmYn(BDDMockito.anyLong(), BDDMockito.anyBoolean());
+			BDDMockito.willDoNothing()
+				.given(menteeScheduleService).deleteMenteeSchedule(BDDMockito.anyLong());
+
+			cancelRequestService.confirmCancelRequest(1L, 1L);
+
+			BDDMockito.verify(cancelRequestMapper).findById(1L);
+			BDDMockito.verify(cancelRequestMapper).updateConfirmYn(1L, true);
+			BDDMockito.verify(menteeScheduleService).deleteMenteeSchedule(1L);
+		}
+
+		@Test
+		@DisplayName("취소 요청 내역이 존재하지 않으면 NotFoundCancelRequestException이 발생한다.")
+		void when_cancelRequestNotExists_expect_throwsNotFoundCancelRequestException() {
+			BDDMockito.given(cancelRequestMapper.findById(BDDMockito.anyLong()))
+				.willReturn(Optional.empty());
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					cancelRequestService.confirmCancelRequest(1L, 1L))
+				.isInstanceOf(NotFoundCancelRequestException.class);
+		}
+
+		@Test
+		@DisplayName("이미 확인된 취소 요청이라면 ConfirmedCancelRequestException이 발생한다.")
+		void when_confirmStatusIsTrue_expect_throwsConfirmedCancelRequestException() {
+			CancelRequest confirmedRequest = CancelRequest.of(1L, 1L, 4L, 3L,
+				"취소 사유", true, LocalDateTime.now(), LocalDateTime.now());
+
+			BDDMockito.given(cancelRequestMapper.findById(BDDMockito.anyLong()))
+				.willReturn(Optional.of(confirmedRequest));
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					cancelRequestService.confirmCancelRequest(1L, 1L))
+				.isInstanceOf(ConfirmedCancelRequestException.class);
+		}
+	}
+}

--- a/src/test/java/cobook/buddywisdom/mentee/service/MenteeScheduleServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/service/MenteeScheduleServiceTest.java
@@ -57,7 +57,6 @@ public class MenteeScheduleServiceTest {
 	private static final long COACH_ID = 1;
 	private static final long SCHEDULE_ID = 1;
 
-
 	@Nested
 	@DisplayName("월별 스케줄 조회")
 	class MonthlyScheduleTest {
@@ -100,7 +99,7 @@ public class MenteeScheduleServiceTest {
 			MenteeScheduleFeedback menteeScheduleFeedback =
 				MenteeScheduleFeedback.of(SCHEDULE_ID, 1L, "코치 피드백", "멘티 피드백", LocalDateTime.now());
 
-			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
+			BDDMockito.given(menteeScheduleMapper.findWithFeedbackByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
 				.willReturn(Optional.of(menteeScheduleFeedback));
 
 			MenteeScheduleFeedbackResponseDto expectedResponse =
@@ -113,7 +112,7 @@ public class MenteeScheduleServiceTest {
 		@Test
 		@DisplayName("해당하는 스케줄 정보가 존재하지 않으면 NotFoundMenteeScheduleException이 발생한다.")
 		void when_scheduleDoesNotExists_expect_throwsNotFoundMenteeScheduleException() {
-			BDDMockito.given(menteeScheduleMapper.findByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
+			BDDMockito.given(menteeScheduleMapper.findWithFeedbackByMenteeIdAndCoachingScheduleId(BDDMockito.anyLong(), BDDMockito.anyLong()))
 				.willThrow(NotFoundMenteeScheduleException.class);
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->
@@ -281,6 +280,34 @@ public class MenteeScheduleServiceTest {
 			AssertionsForClassTypes.assertThatThrownBy(() ->
 					menteeScheduleService.updateMenteeSchedule(request))
 				.isInstanceOf(NotFoundCoachScheduleException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("코칭 일정 취소")
+	class DeleteScheduleTest {
+		@Test
+		@DisplayName("해당 스케줄이 존재하면 일정을 삭제한다.")
+		void when_scheduleExists_expect_deleteSchedule() {
+			MenteeSchedule menteeSchedule = MenteeSchedule.of(SCHEDULE_ID, MENTEE_ID);
+
+			BDDMockito.given(menteeScheduleMapper.findByCoachingScheduleId(BDDMockito.anyLong()))
+				.willReturn(Optional.of(menteeSchedule));
+
+			menteeScheduleService.deleteMenteeSchedule(SCHEDULE_ID);
+
+			BDDMockito.verify(menteeScheduleMapper).findByCoachingScheduleId(SCHEDULE_ID);
+		}
+
+		@Test
+		@DisplayName("해당 스케줄이 존재하지 않으면 NotFoundMenteeScheduleException이 발생한다.")
+		void when_scheduleNotExists_expect_throwsNotFoundMenteeScheduleException() {
+			BDDMockito.given(menteeScheduleMapper.findByCoachingScheduleId(BDDMockito.anyLong()))
+				.willReturn(Optional.empty());
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					menteeScheduleService.deleteMenteeSchedule(SCHEDULE_ID))
+				.isInstanceOf(NotFoundMenteeScheduleException.class);
 		}
 	}
 


### PR DESCRIPTION
### 작업 내용
- 멘티가 코치에게 해당 `mentee_schedule_id`에 대한 취소 요청 내역을 생성한다.
- 멘티가 보낸/받은 취소 내역을 조회한다.
- 멘티가 코치가 보낸 취소 요청 내역을 확인(확정)한다.
- 확인(확정)한 일정은 `mentee_schedule` 테이블에서 삭제된다.