### PR TITLE
멘티 일정 변경 사항을 피드 메시지로 저장한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,10 +89,13 @@ dependencies {
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
+    testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestController.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestController.java
@@ -44,8 +44,9 @@ public class MenteeCancelRequestController {
 	}
 
 	@PatchMapping(value = "/cancel-request")
-	public ResponseEntity<Void> updateCancelRequest(@RequestBody @Valid ConfirmCancelRequestDto request) {
-		cancelRequestService.confirmCancelRequest(request.id(), request.menteeScheduleId());
+	public ResponseEntity<Void> updateCancelRequest(@AuthenticationPrincipal CustomUserDetails member,
+													@RequestBody @Valid ConfirmCancelRequestDto request) {
+		cancelRequestService.confirmCancelRequest(member.getId(), request.id(), request.menteeScheduleId());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/cobook/buddywisdom/cancellation/service/CancelRequestService.java
+++ b/src/main/java/cobook/buddywisdom/cancellation/service/CancelRequestService.java
@@ -89,6 +89,7 @@ public class CancelRequestService {
 
 	private void produceCancelRequestEvent(long senderId, long receiverId, LocalDateTime localDateTime, String template) {
 		ScheduleEventDetails scheduleEventDetails = ScheduleEventDetails.of(senderId, receiverId, localDateTime);
-		feedMessageProducer.produceScheduleEvent(scheduleEventManager.createByBaseSchedule(scheduleEventDetails,template));
+		feedMessageProducer.produceScheduleEvent(
+			scheduleEventManager.createByScheduleDetails(scheduleEventDetails,template));
 	}
 }

--- a/src/main/java/cobook/buddywisdom/feed/domain/Feed.java
+++ b/src/main/java/cobook/buddywisdom/feed/domain/Feed.java
@@ -1,0 +1,25 @@
+package cobook.buddywisdom.feed.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Feed {
+	private Long id;
+	private Long senderId;
+	private Long receiverId;
+	private String feedMessage;
+	private LocalDateTime createdAt;
+
+	public static Feed of(Long senderId, Long receiverId, String feedMesage) {
+		Feed feed = new Feed();
+		feed.senderId = senderId;
+		feed.receiverId = receiverId;
+		feed.feedMessage = feedMesage;
+		return feed;
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feed/domain/Feed.java
+++ b/src/main/java/cobook/buddywisdom/feed/domain/Feed.java
@@ -13,13 +13,28 @@ public class Feed {
 	private Long senderId;
 	private Long receiverId;
 	private String feedMessage;
+	private boolean checkYn;
 	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 
-	public static Feed of(Long senderId, Long receiverId, String feedMesage) {
+	public static Feed of(Long id, Long senderId, Long receiverId, String feedMessage,
+							boolean checkYn, LocalDateTime createdAt, LocalDateTime updatedAt) {
+		Feed feed = new Feed();
+		feed.id = id;
+		feed.senderId = senderId;
+		feed.receiverId = receiverId;
+		feed.feedMessage = feedMessage;
+		feed.checkYn = checkYn;
+		feed.createdAt = createdAt;
+		feed.updatedAt = updatedAt;
+		return feed;
+	}
+
+	public static Feed requestOf(Long senderId, Long receiverId, String feedMessage) {
 		Feed feed = new Feed();
 		feed.senderId = senderId;
 		feed.receiverId = receiverId;
-		feed.feedMessage = feedMesage;
+		feed.feedMessage = feedMessage;
 		return feed;
 	}
 }

--- a/src/main/java/cobook/buddywisdom/feed/dto/ScheduleEventDto.java
+++ b/src/main/java/cobook/buddywisdom/feed/dto/ScheduleEventDto.java
@@ -1,0 +1,8 @@
+package cobook.buddywisdom.feed.dto;
+
+public record ScheduleEventDto (
+	long senderId,
+	long receiverId,
+	String feedMessage
+) {
+}

--- a/src/main/java/cobook/buddywisdom/feed/mapper/FeedMapper.java
+++ b/src/main/java/cobook/buddywisdom/feed/mapper/FeedMapper.java
@@ -1,0 +1,10 @@
+package cobook.buddywisdom.feed.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import cobook.buddywisdom.feed.domain.Feed;
+
+@Mapper
+public interface FeedMapper {
+	void save(Feed feed);
+}

--- a/src/main/java/cobook/buddywisdom/feed/service/FeedService.java
+++ b/src/main/java/cobook/buddywisdom/feed/service/FeedService.java
@@ -1,0 +1,22 @@
+package cobook.buddywisdom.feed.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import cobook.buddywisdom.feed.domain.Feed;
+import cobook.buddywisdom.feed.mapper.FeedMapper;
+
+@Service
+public class FeedService {
+
+	private final FeedMapper feedMapper;
+
+	public FeedService(FeedMapper feedMapper) {
+		this.feedMapper = feedMapper;
+	}
+
+	@Transactional
+	public void saveFeed(long senderId, long receiverId, String message) {
+		feedMapper.save(Feed.of(senderId, receiverId, message));
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feed/service/FeedService.java
+++ b/src/main/java/cobook/buddywisdom/feed/service/FeedService.java
@@ -17,6 +17,6 @@ public class FeedService {
 
 	@Transactional
 	public void saveFeed(long senderId, long receiverId, String message) {
-		feedMapper.save(Feed.of(senderId, receiverId, message));
+		feedMapper.save(Feed.requestOf(senderId, receiverId, message));
 	}
 }

--- a/src/main/java/cobook/buddywisdom/global/util/MessageUtil.java
+++ b/src/main/java/cobook/buddywisdom/global/util/MessageUtil.java
@@ -1,0 +1,16 @@
+package cobook.buddywisdom.global.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageUtil {
+
+	public String convertToString(LocalDateTime scheduleDateTime) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm");
+
+		return scheduleDateTime.format(formatter);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/global/util/ScheduleEventManager.java
+++ b/src/main/java/cobook/buddywisdom/global/util/ScheduleEventManager.java
@@ -17,7 +17,7 @@ public class ScheduleEventManager {
 		this.messageUtil = messageUtil;
 	}
 
-	public ScheduleEventDto createByBaseSchedule(ScheduleEventDetails schedule, String template) {
+	public ScheduleEventDto createByScheduleDetails(ScheduleEventDetails schedule, String template) {
 		String convertedDateTime = messageUtil.convertToString(schedule.getScheduleDateTime());
 
 		String message = MessageFormat.format(template, convertedDateTime);
@@ -29,7 +29,7 @@ public class ScheduleEventManager {
 		);
 	}
 
-	public ScheduleEventDto createByUpdateSchedule(UpdateScheduleEventDetails updateScheduleEventDetails, String template) {
+	public ScheduleEventDto createByUpdateScheduleDetails(UpdateScheduleEventDetails updateScheduleEventDetails, String template) {
 		ScheduleEventDetails scheduleEventDetails = updateScheduleEventDetails.getScheduleEventDetails();
 		String current = messageUtil.convertToString(scheduleEventDetails.getScheduleDateTime());
 		String newSchedule = messageUtil.convertToString(updateScheduleEventDetails.getNewCoachingDateTime());

--- a/src/main/java/cobook/buddywisdom/global/util/ScheduleEventManager.java
+++ b/src/main/java/cobook/buddywisdom/global/util/ScheduleEventManager.java
@@ -1,0 +1,45 @@
+package cobook.buddywisdom.global.util;
+
+import java.text.MessageFormat;
+
+import org.springframework.stereotype.Component;
+
+import cobook.buddywisdom.global.vo.ScheduleEventDetails;
+import cobook.buddywisdom.feed.dto.ScheduleEventDto;
+import cobook.buddywisdom.global.vo.UpdateScheduleEventDetails;
+
+@Component
+public class ScheduleEventManager {
+
+	private final MessageUtil messageUtil;
+
+	public ScheduleEventManager(MessageUtil messageUtil) {
+		this.messageUtil = messageUtil;
+	}
+
+	public ScheduleEventDto createByBaseSchedule(ScheduleEventDetails schedule, String template) {
+		String convertedDateTime = messageUtil.convertToString(schedule.getScheduleDateTime());
+
+		String message = MessageFormat.format(template, convertedDateTime);
+
+		return new ScheduleEventDto(
+			schedule.getSenderId(),
+			schedule.getReceiverId(),
+			message
+		);
+	}
+
+	public ScheduleEventDto createByUpdateSchedule(UpdateScheduleEventDetails updateScheduleEventDetails, String template) {
+		ScheduleEventDetails scheduleEventDetails = updateScheduleEventDetails.getScheduleEventDetails();
+		String current = messageUtil.convertToString(scheduleEventDetails.getScheduleDateTime());
+		String newSchedule = messageUtil.convertToString(updateScheduleEventDetails.getNewCoachingDateTime());
+
+		String message = MessageFormat.format(template, current, newSchedule);
+
+		return new ScheduleEventDto(
+			scheduleEventDetails.getSenderId(),
+			scheduleEventDetails.getReceiverId(),
+			message
+		);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/global/vo/MessageTemplate.java
+++ b/src/main/java/cobook/buddywisdom/global/vo/MessageTemplate.java
@@ -1,0 +1,20 @@
+package cobook.buddywisdom.global.vo;
+
+public enum MessageTemplate {
+
+	CREATE_SCHEDULE("%s님이 {0}로 코칭 일정을 신청했습니다."),
+	REQUEST_CANCEL_SCHEDULE("%s님이 {0} 코칭 일정 취소 요청을 보냈습니다."),
+	CONFIRM_CANCEL_SCHEDULE("%s님이 {0} 코칭 일정 취소 요청을 확인했습니다."),
+	UPDATE_SCHEDULE("%s님이 {0}에서 {1}로 코칭 일정을 변경했습니다.")
+	;
+
+	private String template;
+
+	MessageTemplate(String template) {
+		this.template = template;
+	}
+
+	public String getTemplate() {
+		return template;
+	}
+}

--- a/src/main/java/cobook/buddywisdom/global/vo/ScheduleEventDetails.java
+++ b/src/main/java/cobook/buddywisdom/global/vo/ScheduleEventDetails.java
@@ -1,0 +1,25 @@
+package cobook.buddywisdom.global.vo;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ScheduleEventDetails {
+
+	private Long senderId;
+	private Long receiverId;
+	private LocalDateTime scheduleDateTime;
+
+	public static ScheduleEventDetails of(Long senderId, Long receiverId, LocalDateTime scheduleDateTime) {
+		ScheduleEventDetails scheduleEventDetails = new ScheduleEventDetails();
+		scheduleEventDetails.senderId = senderId;
+		scheduleEventDetails.receiverId = receiverId;
+		scheduleEventDetails.scheduleDateTime = scheduleDateTime;
+		return scheduleEventDetails;
+	}
+
+}

--- a/src/main/java/cobook/buddywisdom/global/vo/UpdateScheduleEventDetails.java
+++ b/src/main/java/cobook/buddywisdom/global/vo/UpdateScheduleEventDetails.java
@@ -1,0 +1,25 @@
+package cobook.buddywisdom.global.vo;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateScheduleEventDetails {
+
+	private ScheduleEventDetails scheduleEventDetails;
+
+	private LocalDateTime newCoachingDateTime;
+
+	public static UpdateScheduleEventDetails of(Long senderId, Long receiverId, LocalDateTime currentCoachingDateTime,
+									LocalDateTime newCoachingDateTime) {
+		UpdateScheduleEventDetails updateScheduleEventDetails = new UpdateScheduleEventDetails();
+		updateScheduleEventDetails.scheduleEventDetails = ScheduleEventDetails.of(senderId, receiverId, currentCoachingDateTime);
+		updateScheduleEventDetails.newCoachingDateTime = newCoachingDateTime;
+		return updateScheduleEventDetails;
+	}
+
+}

--- a/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
+++ b/src/main/java/cobook/buddywisdom/mentee/controller/MenteeController.java
@@ -56,8 +56,9 @@ public class MenteeController {
 	}
 
 	@PatchMapping(value = "/schedule")
-	public ResponseEntity<Void> update(@RequestBody @Valid UpdateMenteeScheduleRequestDto request) {
-		menteeScheduleService.updateMenteeSchedule(request);
+	public ResponseEntity<Void> update(@AuthenticationPrincipal CustomUserDetails member,
+										@RequestBody @Valid UpdateMenteeScheduleRequestDto request) {
+		menteeScheduleService.updateMenteeSchedule(member.getId(), request.currentCoachingId(), request.newCoachingId());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -1,5 +1,7 @@
 package cobook.buddywisdom.mentee.service;
 
+import static cobook.buddywisdom.global.vo.MessageTemplate.*;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -10,11 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cobook.buddywisdom.coach.domain.CoachSchedule;
 import cobook.buddywisdom.coach.service.CoachScheduleService;
+import cobook.buddywisdom.global.vo.ScheduleEventDetails;
+import cobook.buddywisdom.global.vo.UpdateScheduleEventDetails;
+import cobook.buddywisdom.global.util.ScheduleEventManager;
 import cobook.buddywisdom.global.exception.ErrorMessage;
 import cobook.buddywisdom.mentee.domain.MenteeMonthlySchedule;
 import cobook.buddywisdom.mentee.domain.MenteeSchedule;
 import cobook.buddywisdom.mentee.domain.MenteeScheduleFeedback;
-import cobook.buddywisdom.mentee.dto.request.UpdateMenteeScheduleRequestDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeMonthlyScheduleResponseDto;
 import cobook.buddywisdom.mentee.dto.response.MenteeScheduleFeedbackResponseDto;
 import cobook.buddywisdom.mentee.dto.request.MenteeMonthlyScheduleRequestDto;
@@ -24,25 +28,23 @@ import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotAllowedUpdateException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
 import cobook.buddywisdom.mentee.mapper.MenteeScheduleMapper;
+import cobook.buddywisdom.messaging.producer.FeedMessageProducer;
 import cobook.buddywisdom.relationship.domain.CoachingRelationship;
 import cobook.buddywisdom.relationship.service.CoachingRelationshipService;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class MenteeScheduleService {
 
 	private final MenteeScheduleMapper menteeScheduleMapper;
 	private final CoachScheduleService coachScheduleService;
 	private final CoachingRelationshipService coachingRelationshipService;
+	private final FeedMessageProducer feedMessageProducer;
+	private final ScheduleEventManager scheduleEventManager;
 
 	private static final int DEFAULT_DAYS = 8;
-
-	public MenteeScheduleService(MenteeScheduleMapper menteeScheduleMapper, CoachScheduleService coachScheduleService,
-		CoachingRelationshipService coachingRelationshipService) {
-		this.menteeScheduleMapper = menteeScheduleMapper;
-		this.coachScheduleService = coachScheduleService;
-		this.coachingRelationshipService = coachingRelationshipService;
-	}
 
 	public List<MenteeMonthlyScheduleResponseDto> getMenteeMonthlySchedule(long menteeId, MenteeMonthlyScheduleRequestDto request) {
 		List<MenteeMonthlySchedule> menteeMonthlyScheduleList =
@@ -84,7 +86,7 @@ public class MenteeScheduleService {
 
 	@Transactional
 	public MenteeScheduleResponseDto saveMenteeSchedule(long menteeId, long coachingScheduleId) {
-		coachScheduleService.getCoachSchedule(coachingScheduleId,false);
+		CoachSchedule coachSchedule = coachScheduleService.getCoachSchedule(coachingScheduleId,false);
 
 		checkMenteeScheduleNotExist(coachingScheduleId);
 
@@ -92,6 +94,10 @@ public class MenteeScheduleService {
 		menteeScheduleMapper.save(menteeSchedule);
 
 		coachScheduleService.updateMatchYn(coachingScheduleId, true);
+
+		ScheduleEventDetails scheduleEventDetails =
+			ScheduleEventDetails.of(menteeId, coachSchedule.getCoachId(), coachSchedule.getPossibleDateTime());
+		feedMessageProducer.produceScheduleEvent(scheduleEventManager.createByBaseSchedule(scheduleEventDetails, CREATE_SCHEDULE.getTemplate()));
 
 		return MenteeScheduleResponseDto.from(menteeSchedule);
 	}
@@ -107,21 +113,22 @@ public class MenteeScheduleService {
 	}
 
 	@Transactional
-	public void updateMenteeSchedule(UpdateMenteeScheduleRequestDto request) {
-		long currentCoachingId = request.currentCoachingId();
-		long newCoachingId = request.newCoachingId();
+	public void updateMenteeSchedule(long menteeId, long currentCoachingId, long newCoachingId) {
+		CoachSchedule currentCoachSchedule = getScheduleIfUpdatePossible(currentCoachingId);
 
-		checkIfUpdatePossible(currentCoachingId);
-
-		coachScheduleService.getCoachSchedule(newCoachingId, false);
+		CoachSchedule newCoachSchedule = coachScheduleService.getCoachSchedule(newCoachingId, false);
 
 		menteeScheduleMapper.updateCoachingScheduleId(currentCoachingId, newCoachingId);
 
 		coachScheduleService.updateMatchYn(currentCoachingId, false);
 		coachScheduleService.updateMatchYn(newCoachingId, true);
+
+		UpdateScheduleEventDetails updateScheduleEventDetails = UpdateScheduleEventDetails.of(menteeId, currentCoachSchedule.getCoachId(),
+			currentCoachSchedule.getPossibleDateTime(), newCoachSchedule.getPossibleDateTime());
+		feedMessageProducer.produceScheduleEvent(scheduleEventManager.createByUpdateSchedule(updateScheduleEventDetails, UPDATE_SCHEDULE.getTemplate()));
 	}
 
-	public void checkIfUpdatePossible(long coachScheduleId) {
+	public CoachSchedule getScheduleIfUpdatePossible(long coachScheduleId) {
 		CoachSchedule currentCoachSchedule = coachScheduleService.getCoachSchedule(coachScheduleId, true);
 
 		LocalDate date = LocalDate.from(currentCoachSchedule.getPossibleDateTime());
@@ -129,6 +136,8 @@ public class MenteeScheduleService {
 		if (!LocalDate.now().isBefore(date)) {
 			throw new NotAllowedUpdateException(ErrorMessage.NOT_ALLOWED_UPDATE_SCHEDULE);
 		}
+
+		return currentCoachSchedule;
 	}
 
 	@Transactional

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -97,7 +97,8 @@ public class MenteeScheduleService {
 
 		ScheduleEventDetails scheduleEventDetails =
 			ScheduleEventDetails.of(menteeId, coachSchedule.getCoachId(), coachSchedule.getPossibleDateTime());
-		feedMessageProducer.produceScheduleEvent(scheduleEventManager.createByBaseSchedule(scheduleEventDetails, CREATE_SCHEDULE.getTemplate()));
+		feedMessageProducer.produceScheduleEvent(
+			scheduleEventManager.createByScheduleDetails(scheduleEventDetails, CREATE_SCHEDULE.getTemplate()));
 
 		return MenteeScheduleResponseDto.from(menteeSchedule);
 	}
@@ -125,7 +126,8 @@ public class MenteeScheduleService {
 
 		UpdateScheduleEventDetails updateScheduleEventDetails = UpdateScheduleEventDetails.of(menteeId, currentCoachSchedule.getCoachId(),
 			currentCoachSchedule.getPossibleDateTime(), newCoachSchedule.getPossibleDateTime());
-		feedMessageProducer.produceScheduleEvent(scheduleEventManager.createByUpdateSchedule(updateScheduleEventDetails, UPDATE_SCHEDULE.getTemplate()));
+		feedMessageProducer.produceScheduleEvent(
+			scheduleEventManager.createByUpdateScheduleDetails(updateScheduleEventDetails, UPDATE_SCHEDULE.getTemplate()));
 	}
 
 	public CoachSchedule getScheduleIfUpdatePossible(long coachScheduleId) {

--- a/src/main/java/cobook/buddywisdom/messaging/config/RabbitmqConfig.java
+++ b/src/main/java/cobook/buddywisdom/messaging/config/RabbitmqConfig.java
@@ -1,0 +1,23 @@
+package cobook.buddywisdom.messaging.config;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitmqConfig {
+
+	@Bean
+	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+		rabbitTemplate.setMessageConverter(jsonMessageConverter());
+		return rabbitTemplate;
+	}
+
+	@Bean
+	public Jackson2JsonMessageConverter jsonMessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+}

--- a/src/main/java/cobook/buddywisdom/messaging/consumer/FeedMessageConsumer.java
+++ b/src/main/java/cobook/buddywisdom/messaging/consumer/FeedMessageConsumer.java
@@ -1,0 +1,28 @@
+package cobook.buddywisdom.messaging.consumer;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import cobook.buddywisdom.feed.service.FeedService;
+import cobook.buddywisdom.feed.dto.ScheduleEventDto;
+
+@Component
+public class FeedMessageConsumer {
+
+	private final FeedService feedService;
+
+	private static final String SCHEDULE_QUEUE = "schedule.events";
+
+	public FeedMessageConsumer(FeedService feedService) {
+		this.feedService = feedService;
+	}
+
+	@RabbitListener(queues = SCHEDULE_QUEUE)
+	public void consumeFromScheduleEvents(ScheduleEventDto scheduleEventDto) {
+		feedService.saveFeed(
+			scheduleEventDto.senderId(),
+			scheduleEventDto.receiverId(),
+			scheduleEventDto.feedMessage()
+		);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/messaging/producer/FeedMessageProducer.java
+++ b/src/main/java/cobook/buddywisdom/messaging/producer/FeedMessageProducer.java
@@ -1,0 +1,25 @@
+package cobook.buddywisdom.messaging.producer;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import cobook.buddywisdom.feed.dto.ScheduleEventDto;
+
+@Component
+public class FeedMessageProducer {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	private static final String EXCHANGE = "budsdom.events";
+	private static final String SCHEDULE_ROUTING_KEY = "schedule.events";
+
+	public FeedMessageProducer(RabbitTemplate rabbitTemplate) {
+		this.rabbitTemplate = rabbitTemplate;
+	}
+
+	public void produceScheduleEvent(ScheduleEventDto scheduleEventDto) {
+		rabbitTemplate.convertAndSend(EXCHANGE, SCHEDULE_ROUTING_KEY, scheduleEventDto);
+	}
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,12 @@ spring:
     username: ${{ secrets.DB_USERNAME }}
     password: ${{ secrets.DB_PASSWORD }}
 
+  rabbitmq:
+    host: ${{ secrets.MQ_HOST }}
+    port: ${{ secrets.MQ_PORT }}
+    username: ${{ secrets.MQ_USERNAME }}
+    password: ${{ secrets.MQ_PASSWORD }}
+
 # mybatis
 mybatis:
   configuration:

--- a/src/main/resources/mapper/feed/FeedMapper.xml
+++ b/src/main/resources/mapper/feed/FeedMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="cobook.buddywisdom.feed.mapper.FeedMapper">
+
+    <sql id="feedColumns">
+        sender_id,
+        receiver_id,
+        feed_message,
+        created_at
+    </sql>
+
+    <insert id="save" parameterType="Feed">
+        INSERT INTO feed(
+            <include refid="feedColumns"></include>
+        )
+        VALUES (
+        #{senderId},
+        #{receiverId},
+        #{feedMessage},
+        NOW()
+        )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/feed/FeedMapper.xml
+++ b/src/main/resources/mapper/feed/FeedMapper.xml
@@ -9,7 +9,8 @@
         sender_id,
         receiver_id,
         feed_message,
-        created_at
+        created_at,
+        updated_at
     </sql>
 
     <insert id="save" parameterType="Feed">
@@ -20,6 +21,7 @@
         #{senderId},
         #{receiverId},
         #{feedMessage},
+        NOW(),
         NOW()
         )
     </insert>

--- a/src/test/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/controller/MenteeCancelRequestControllerTest.java
@@ -154,7 +154,7 @@ public class MenteeCancelRequestControllerTest {
 				new ConfirmCancelRequestDto(1L, 1L);
 
 			BDDMockito.willDoNothing()
-				.given(cancelRequestService).confirmCancelRequest(anyLong(), anyLong());
+				.given(cancelRequestService).confirmCancelRequest(anyLong(), anyLong(), anyLong());
 
 			ResultActions response =
 				mockMvc.perform(
@@ -165,7 +165,7 @@ public class MenteeCancelRequestControllerTest {
 					.andDo(MockMvcResultHandlers.print());
 
 			BDDMockito.verify(cancelRequestService)
-				.confirmCancelRequest(anyLong(), anyLong());
+				.confirmCancelRequest(anyLong(), anyLong(), anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 

--- a/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/mentee/controller/MenteeControllerTest.java
@@ -1,6 +1,8 @@
 package cobook.buddywisdom.mentee.controller;
 
 
+import static org.mockito.ArgumentMatchers.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -60,7 +62,7 @@ public class MenteeControllerTest {
 						.content(objectMapper.writeValueAsBytes(request)))
 				.andDo(MockMvcResultHandlers.print());
 
-			BDDMockito.verify(menteeScheduleService).getMenteeMonthlySchedule(BDDMockito.anyLong(), BDDMockito.any());
+			BDDMockito.verify(menteeScheduleService).getMenteeMonthlySchedule(anyLong(), BDDMockito.any());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 
@@ -94,7 +96,7 @@ public class MenteeControllerTest {
 					MockMvcRequestBuilders.get("/api/v1/mentees/schedule/" + scheduleId))
 				.andDo(MockMvcResultHandlers.print());
 
-			BDDMockito.verify(menteeScheduleService).getMenteeScheduleFeedback(BDDMockito.anyLong(), BDDMockito.anyLong());
+			BDDMockito.verify(menteeScheduleService).getMenteeScheduleFeedback(anyLong(), anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 	}
@@ -127,7 +129,7 @@ public class MenteeControllerTest {
 							.with(SecurityMockMvcRequestPostProcessors.csrf()))
 					.andDo(MockMvcResultHandlers.print());
 
-			BDDMockito.verify(menteeScheduleService).saveMenteeSchedule(BDDMockito.anyLong(), BDDMockito.anyLong());
+			BDDMockito.verify(menteeScheduleService).saveMenteeSchedule(anyLong(), anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 	}
@@ -135,7 +137,7 @@ public class MenteeControllerTest {
 	@Nested
 	@DisplayName("코칭 일정 변경")
 	@WithMockCustomUser(role = "MENTEE")
-	class UpdateScheduleTest {
+	class UpdateScheduleEventDetailsTest {
 
 		@Test
 		@DisplayName("스케줄 정보가 모두 전달되면 메서드를 호출하고 200 OK를 반환한다.")
@@ -143,7 +145,7 @@ public class MenteeControllerTest {
 			UpdateMenteeScheduleRequestDto request =
 				new UpdateMenteeScheduleRequestDto(1L, 2L);
 
-			BDDMockito.willDoNothing().given(menteeScheduleService).updateMenteeSchedule(BDDMockito.any());
+			BDDMockito.willDoNothing().given(menteeScheduleService).updateMenteeSchedule(anyLong(), anyLong(), anyLong());
 
 			ResultActions response =
 				mockMvc.perform(
@@ -153,7 +155,7 @@ public class MenteeControllerTest {
 							.with(SecurityMockMvcRequestPostProcessors.csrf()))
 					.andDo(MockMvcResultHandlers.print());
 
-			BDDMockito.verify(menteeScheduleService).updateMenteeSchedule(BDDMockito.any(UpdateMenteeScheduleRequestDto.class));
+			BDDMockito.verify(menteeScheduleService).updateMenteeSchedule(anyLong(), anyLong(), anyLong());
 			response.andExpect(MockMvcResultMatchers.status().isOk());
 		}
 


### PR DESCRIPTION
### 작업 내용
- `RabbitMQ` 의존성 및 관련 설정을 추가한다.
- 멘티 일정 신청/변경/취소 요청/취소 요청 확인 기능에 messaging 로직을 추가한다.
- Feed 테이블에 가공된 데이터를 활용해 정보를 저장한다.

<br>

### 참고 내용
테스트 코드는 추후 PR로 올릴 예정입니다.