### PR TITLE
[#27] 피드백 조회 및 등록 기능을 구현한다. 

### DIFF
--- a/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
+++ b/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
@@ -36,6 +36,6 @@ public class FeedbackController {
 	public ResponseEntity<Void> updateFeedback(@PathVariable final MemberApiType memberApiType,
 												@RequestBody @Valid final UpdateFeedbackRequestDto request) {
 		feedbackService.updateFeedback(request.menteeScheduleId(), request.feedback(), memberApiType);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
+++ b/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
@@ -35,7 +35,12 @@ public class FeedbackController {
 	@PatchMapping("/{memberApiType}/feedback")
 	public ResponseEntity<Void> updateFeedback(@PathVariable final MemberApiType memberApiType,
 												@RequestBody @Valid final UpdateFeedbackRequestDto request) {
-		feedbackService.updateFeedback(request.menteeScheduleId(), request.feedback(), memberApiType);
+		if (MemberApiType.COACHES.equals(memberApiType)) {
+			feedbackService.updateFeedbackByCoach(request.menteeScheduleId(), request.feedback());
+		} else if (MemberApiType.MENTEES.equals(memberApiType)) {
+			feedbackService.updateFeedbackByMentee(request.menteeScheduleId(), request.feedback());
+		}
+
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
+++ b/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
@@ -1,0 +1,41 @@
+package cobook.buddywisdom.feedback.controller;
+
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
+import cobook.buddywisdom.feedback.dto.UpdateFeedbackRequestDto;
+import cobook.buddywisdom.feedback.service.FeedbackService;
+import cobook.buddywisdom.global.vo.MemberApiType;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1")
+public class FeedbackController {
+
+	private final FeedbackService feedbackService;
+
+	public FeedbackController(FeedbackService feedbackService) {
+		this.feedbackService = feedbackService;
+	}
+
+	@GetMapping("/{memberApiType}/feedback/{scheduleId}")
+	public ResponseEntity<Optional<FeedbackResponseDto>> getFeedBack(@PathVariable final MemberApiType memberApiType,
+															@PathVariable final long scheduleId) {
+		return ResponseEntity.ok(feedbackService.getFeedback(scheduleId));
+	}
+
+	@PatchMapping("/{memberApiType}/feedback")
+	public ResponseEntity<Void> updateFeedback(@PathVariable final MemberApiType memberApiType,
+												@RequestBody @Valid final UpdateFeedbackRequestDto request) {
+		feedbackService.updateFeedback(request.menteeScheduleId(), request.feedback(), memberApiType);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feedback/domain/Feedback.java
+++ b/src/main/java/cobook/buddywisdom/feedback/domain/Feedback.java
@@ -1,0 +1,21 @@
+package cobook.buddywisdom.feedback.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Feedback {
+	private Long menteeScheduleId;
+	private String coachFeedback;
+	private String menteeFeedback;
+
+	public static Feedback of(Long menteeScheduleId, String coachFeedback, String menteeFeedback) {
+		Feedback feedback = new Feedback();
+		feedback.menteeScheduleId = menteeScheduleId;
+		feedback.coachFeedback = coachFeedback;
+		feedback.menteeFeedback = menteeFeedback;
+		return feedback;
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feedback/dto/FeedbackResponseDto.java
+++ b/src/main/java/cobook/buddywisdom/feedback/dto/FeedbackResponseDto.java
@@ -1,0 +1,18 @@
+package cobook.buddywisdom.feedback.dto;
+
+import cobook.buddywisdom.feed.domain.Feed;
+import cobook.buddywisdom.feedback.domain.Feedback;
+
+public record FeedbackResponseDto (
+	long menteeScheduleId,
+	String coachFeedback,
+	String menteeFeedback
+) {
+	public static FeedbackResponseDto from(Feedback feedback) {
+		return new FeedbackResponseDto(
+			feedback.getMenteeScheduleId(),
+			feedback.getCoachFeedback(),
+			feedback.getMenteeFeedback()
+		);
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feedback/dto/UpdateFeedbackRequestDto.java
+++ b/src/main/java/cobook/buddywisdom/feedback/dto/UpdateFeedbackRequestDto.java
@@ -1,0 +1,12 @@
+package cobook.buddywisdom.feedback.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateFeedbackRequestDto (
+	@NotNull(message = "스케줄 정보가 필요합니다.")
+	Long menteeScheduleId,
+	@NotBlank(message = "피드백을 입력해 주세요.")
+	String feedback
+) {
+}

--- a/src/main/java/cobook/buddywisdom/feedback/exception/NotFoundFeedbackException.java
+++ b/src/main/java/cobook/buddywisdom/feedback/exception/NotFoundFeedbackException.java
@@ -1,0 +1,9 @@
+package cobook.buddywisdom.feedback.exception;
+
+import cobook.buddywisdom.global.exception.ErrorMessage;
+
+public class NotFoundFeedbackException extends RuntimeException {
+	public NotFoundFeedbackException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feedback/mapper/FeedbackMapper.java
+++ b/src/main/java/cobook/buddywisdom/feedback/mapper/FeedbackMapper.java
@@ -1,0 +1,14 @@
+package cobook.buddywisdom.feedback.mapper;
+
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import cobook.buddywisdom.feedback.domain.Feedback;
+
+@Mapper
+public interface FeedbackMapper {
+	Optional<Feedback> findByMenteeScheduleId(long menteeScheduleId);
+	void updateCoachFeedbackByMenteeScheduleId(long menteeScheduleId, String feedback);
+	void updateMenteeFeedbackByMenteeScheduleId(long menteeScheduleId, String feedback);
+}

--- a/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
+++ b/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
@@ -1,0 +1,41 @@
+package cobook.buddywisdom.feedback.service;
+
+import static cobook.buddywisdom.global.vo.MemberApiType.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import cobook.buddywisdom.feedback.domain.Feedback;
+import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
+import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
+import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
+import cobook.buddywisdom.global.exception.ErrorMessage;
+import cobook.buddywisdom.global.vo.MemberApiType;
+import cobook.buddywisdom.mentee.service.MenteeScheduleService;
+
+@Service
+public class FeedbackService {
+
+	private final FeedbackMapper feedbackMapper;
+
+	public FeedbackService(FeedbackMapper feedbackMapper) {
+		this.feedbackMapper = feedbackMapper;
+	}
+
+	public Optional<FeedbackResponseDto> getFeedback(long menteeScheduleId) {
+		return feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
+			.map(FeedbackResponseDto::from);
+	}
+
+	public void updateFeedback(long menteeScheduleId, String feedback, MemberApiType apiType) {
+		feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
+			.orElseThrow(() -> new NotFoundFeedbackException(ErrorMessage.NOT_FOUND_FEEDBACK));
+
+		if (COACHES.equals(apiType)) {
+			feedbackMapper.updateCoachFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
+		} else if (MENTEES.equals(apiType)) {
+			feedbackMapper.updateMenteeFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
+		}
+	}
+}

--- a/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
+++ b/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
@@ -1,7 +1,5 @@
 package cobook.buddywisdom.feedback.service;
 
-import static cobook.buddywisdom.global.vo.MemberApiType.*;
-
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -10,7 +8,6 @@ import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
 import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
 import cobook.buddywisdom.global.exception.ErrorMessage;
-import cobook.buddywisdom.global.vo.MemberApiType;
 
 @Service
 public class FeedbackService {
@@ -26,14 +23,18 @@ public class FeedbackService {
 			.map(FeedbackResponseDto::from);
 	}
 
-	public void updateFeedback(long menteeScheduleId, String feedback, MemberApiType apiType) {
+	public void updateFeedbackByCoach(long menteeScheduleId, String feedback) {
 		feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
 			.orElseThrow(() -> new NotFoundFeedbackException(ErrorMessage.NOT_FOUND_FEEDBACK));
 
-		if (COACHES.equals(apiType)) {
-			feedbackMapper.updateCoachFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
-		} else if (MENTEES.equals(apiType)) {
-			feedbackMapper.updateMenteeFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
-		}
+		feedbackMapper.updateCoachFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
+	}
+
+	public void updateFeedbackByMentee(long menteeScheduleId, String feedback) {
+		feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
+			.orElseThrow(() -> new NotFoundFeedbackException(ErrorMessage.NOT_FOUND_FEEDBACK));
+
+		feedbackMapper.updateMenteeFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
+
 	}
 }

--- a/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
+++ b/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
@@ -6,13 +6,11 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import cobook.buddywisdom.feedback.domain.Feedback;
 import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
 import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
 import cobook.buddywisdom.global.exception.ErrorMessage;
 import cobook.buddywisdom.global.vo.MemberApiType;
-import cobook.buddywisdom.mentee.service.MenteeScheduleService;
 
 @Service
 public class FeedbackService {

--- a/src/main/java/cobook/buddywisdom/global/config/WebConfig.java
+++ b/src/main/java/cobook/buddywisdom/global/config/WebConfig.java
@@ -1,0 +1,15 @@
+package cobook.buddywisdom.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import cobook.buddywisdom.global.util.MemberApiTypeConverter;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new MemberApiTypeConverter());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import cobook.buddywisdom.cancellation.exception.ConfirmedCancelRequestException;
 import cobook.buddywisdom.cancellation.exception.NotFoundCancelRequestException;
 import cobook.buddywisdom.coach.exception.NotFoundCoachScheduleException;
+import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
 import cobook.buddywisdom.mentee.exception.DuplicatedMenteeScheduleException;
 import cobook.buddywisdom.mentee.exception.NotAllowedUpdateException;
 import cobook.buddywisdom.mentee.exception.NotFoundMenteeScheduleException;
@@ -73,5 +74,11 @@ public class ApiExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleConfirmedCancelRequestException(ConfirmedCancelRequestException exception) {
 		log.error("ConfirmedCancelRequestException : ", exception);
 		return ErrorResponse.toResponseEntity(ErrorMessage.CONFIRMED_CANCEL_REQUEST);
+	}
+
+	@ExceptionHandler(NotFoundFeedbackException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundFeedbackException(NotFoundFeedbackException exception) {
+		log.error("NotFoundFeedbackException : ", exception);
+		return ErrorResponse.toResponseEntity(ErrorMessage.NOT_FOUND_FEEDBACK);
 	}
 }

--- a/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
+++ b/src/main/java/cobook/buddywisdom/global/exception/ErrorMessage.java
@@ -24,7 +24,10 @@ public enum ErrorMessage {
 
 	// CANCEL_REQUEST
 	NOT_FOUND_CANCEL_REQUEST(HttpStatus.NOT_FOUND, "등록된 일정 취소 요청이 존재하지 않습니다."),
-	CONFIRMED_CANCEL_REQUEST(HttpStatus.BAD_REQUEST, "이미 확인이 완료된 취소 요청입니다.")
+	CONFIRMED_CANCEL_REQUEST(HttpStatus.BAD_REQUEST, "이미 확인이 완료된 취소 요청입니다."),
+
+	// FEEDBACK
+	NOT_FOUND_FEEDBACK(HttpStatus.NOT_FOUND, "등록된 피드백이 존재하지 않습니다.")
 	;
 
 	private HttpStatus status;

--- a/src/main/java/cobook/buddywisdom/global/util/MemberApiTypeConverter.java
+++ b/src/main/java/cobook/buddywisdom/global/util/MemberApiTypeConverter.java
@@ -1,0 +1,12 @@
+package cobook.buddywisdom.global.util;
+
+import org.springframework.core.convert.converter.Converter;
+
+import cobook.buddywisdom.global.vo.MemberApiType;
+
+public class MemberApiTypeConverter implements Converter<String, MemberApiType> {
+	@Override
+	public MemberApiType convert(String memberApiType) {
+		return MemberApiType.valueOf(memberApiType.toUpperCase());
+	}
+}

--- a/src/main/java/cobook/buddywisdom/global/vo/MemberApiType.java
+++ b/src/main/java/cobook/buddywisdom/global/vo/MemberApiType.java
@@ -1,0 +1,15 @@
+package cobook.buddywisdom.global.vo;
+
+public enum MemberApiType {
+	MENTEES("mentees"), COACHES("coaches");
+
+	private String value;
+
+	MemberApiType(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/src/main/resources/mapper/feedback/FeedbackMapper.xml
+++ b/src/main/resources/mapper/feedback/FeedbackMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="cobook.buddywisdom.feedback.mapper.FeedbackMapper">
+
+    <select id="findByMenteeScheduleId" parameterType="long" resultType="Feedback">
+        SELECT
+            mentee_schedule_id,
+            coach_feedback,
+            mentee_feedback
+        FROM feedback
+        WHERE mentee_schedule_id = #{menteeScheduleId}
+    </select>
+
+    <update id="updateCoachFeedbackByMenteeScheduleId" parameterType="map">
+        UPDATE feedback
+        SET coach_feedback = #{feedback}
+        WHERE mentee_schedule_id = #{menteeScheduleId}
+    </update>
+
+    <update id="updateMenteeFeedbackByMenteeScheduleId" parameterType="map">
+        UPDATE feedback
+        SET mentee_feedback = #{feedback}
+        WHERE mentee_schedule_id = #{menteeScheduleId}
+    </update>
+
+</mapper>

--- a/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
@@ -1,5 +1,6 @@
 package cobook.buddywisdom.feedback.controller;
 
+import static cobook.buddywisdom.global.vo.MemberApiType.*;
 import static org.mockito.ArgumentMatchers.*;
 
 import java.util.Optional;
@@ -12,7 +13,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.BDDMockito;
 import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -23,14 +23,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import cobook.buddywisdom.feedback.domain.Feedback;
 import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.dto.UpdateFeedbackRequestDto;
 import cobook.buddywisdom.feedback.service.FeedbackService;
-import cobook.buddywisdom.global.vo.MemberApiType;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
 @AutoConfigureMybatis
@@ -78,25 +76,45 @@ public class FeedbackControllerTest {
 	@WithMockCustomUser
 	@DisplayName("피드백 확인")
 	class UpdateFeedbackTest {
-		@ParameterizedTest
-		@ValueSource(strings = {"coaches", "mentees"})
-		@DisplayName("유효한 피드백 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
-		void when_requestInformationIsValid_expect_callMethodAndReturn200Ok(String memberApiType) throws Exception {
-			UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "피드백");
+		@Test
+		@DisplayName("유효한 멘티의 피드백 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_menteeRequestInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+			UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "멘티 피드백");
 
 			BDDMockito.willDoNothing()
-				.given(feedbackService).updateFeedback(anyLong(), anyString(), any(MemberApiType.class));
+				.given(feedbackService).updateFeedbackByMentee(anyLong(), anyString());
 
 			ResultActions response =
 				mockMvc.perform(
-					MockMvcRequestBuilders.patch(BASE_URL + memberApiType + "/feedback")
+					MockMvcRequestBuilders.patch(BASE_URL + MENTEES + "/feedback")
 						.with(SecurityMockMvcRequestPostProcessors.csrf())
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(request)))
 				.andDo(MockMvcResultHandlers.print());
 
-			BDDMockito.verify(feedbackService).updateFeedback(anyLong(), anyString(), any(MemberApiType.class));
+			BDDMockito.verify(feedbackService).updateFeedbackByMentee(anyLong(), anyString());
 			response.andExpect(MockMvcResultMatchers.status().isNoContent());
 		}
 	}
+
+	@Test
+	@DisplayName("유효한 코치의 피드백 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+	void when_coachRequestInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+		UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "코치 피드백");
+
+		BDDMockito.willDoNothing()
+			.given(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
+
+		ResultActions response =
+			mockMvc.perform(
+					MockMvcRequestBuilders.patch(BASE_URL + COACHES + "/feedback")
+						.with(SecurityMockMvcRequestPostProcessors.csrf())
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andDo(MockMvcResultHandlers.print());
+
+		BDDMockito.verify(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
+		response.andExpect(MockMvcResultMatchers.status().isNoContent());
+	}
 }
+

--- a/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
@@ -95,26 +95,26 @@ public class FeedbackControllerTest {
 			BDDMockito.verify(feedbackService).updateFeedbackByMentee(anyLong(), anyString());
 			response.andExpect(MockMvcResultMatchers.status().isNoContent());
 		}
-	}
 
-	@Test
-	@DisplayName("유효한 코치의 피드백 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
-	void when_coachRequestInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
-		UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "코치 피드백");
+		@Test
+		@DisplayName("유효한 코치의 피드백 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_coachRequestInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
+			UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "코치 피드백");
 
-		BDDMockito.willDoNothing()
-			.given(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
+			BDDMockito.willDoNothing()
+				.given(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
 
-		ResultActions response =
-			mockMvc.perform(
-					MockMvcRequestBuilders.patch(BASE_URL + COACHES + "/feedback")
-						.with(SecurityMockMvcRequestPostProcessors.csrf())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andDo(MockMvcResultHandlers.print());
+			ResultActions response =
+				mockMvc.perform(
+						MockMvcRequestBuilders.patch(BASE_URL + COACHES + "/feedback")
+							.with(SecurityMockMvcRequestPostProcessors.csrf())
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(request)))
+					.andDo(MockMvcResultHandlers.print());
 
-		BDDMockito.verify(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
-		response.andExpect(MockMvcResultMatchers.status().isNoContent());
+			BDDMockito.verify(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
+			response.andExpect(MockMvcResultMatchers.status().isNoContent());
+		}
 	}
 }
 

--- a/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
@@ -1,0 +1,102 @@
+package cobook.buddywisdom.feedback.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.BDDMockito;
+import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cobook.buddywisdom.feedback.domain.Feedback;
+import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
+import cobook.buddywisdom.feedback.dto.UpdateFeedbackRequestDto;
+import cobook.buddywisdom.feedback.service.FeedbackService;
+import cobook.buddywisdom.global.vo.MemberApiType;
+import cobook.buddywisdom.util.WithMockCustomUser;
+
+@AutoConfigureMybatis
+@WebMvcTest(FeedbackController.class)
+public class FeedbackControllerTest {
+
+	@MockBean
+	private FeedbackService feedbackService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private static final String BASE_URL = "/api/v1/";
+
+	@Nested
+	@WithMockCustomUser
+	@DisplayName("피드백 조회")
+	class FeedbackTest {
+		@ParameterizedTest
+		@ValueSource(strings = {"coaches", "mentees"})
+		@DisplayName("유효한 스케줄 id를 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_scheduleIdIsValid_expect_callMethodAndReturn200Ok(String memberApiType) throws Exception {
+			Long scheduleId = 1L;
+
+			Feedback feedback = Feedback.of(scheduleId, "코치 피드백", "멘티 피드백");
+			FeedbackResponseDto feedbackResponseDto = FeedbackResponseDto.from(feedback);
+
+			BDDMockito.given(feedbackService.getFeedback(anyLong()))
+				.willReturn(Optional.of(feedbackResponseDto));
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.get(BASE_URL + memberApiType + "/feedback/" + scheduleId))
+				.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(feedbackService).getFeedback(anyLong());
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+	}
+
+	@Nested
+	@WithMockCustomUser
+	@DisplayName("피드백 확인")
+	class UpdateFeedbackTest {
+		@ParameterizedTest
+		@ValueSource(strings = {"coaches", "mentees"})
+		@DisplayName("유효한 피드백 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_requestInformationIsValid_expect_callMethodAndReturn200Ok(String memberApiType) throws Exception {
+			UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "피드백");
+
+			BDDMockito.willDoNothing()
+				.given(feedbackService).updateFeedback(anyLong(), anyString(), any(MemberApiType.class));
+
+			ResultActions response =
+				mockMvc.perform(
+					MockMvcRequestBuilders.patch(BASE_URL + memberApiType + "/feedback")
+						.with(SecurityMockMvcRequestPostProcessors.csrf())
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andDo(MockMvcResultHandlers.print());
+
+			BDDMockito.verify(feedbackService).updateFeedback(anyLong(), anyString(), any(MemberApiType.class));
+			response.andExpect(MockMvcResultMatchers.status().isNoContent());
+		}
+	}
+}

--- a/src/test/java/cobook/buddywisdom/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/service/FeedbackServiceTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -21,7 +19,6 @@ import cobook.buddywisdom.feedback.domain.Feedback;
 import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
 import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
-import cobook.buddywisdom.global.vo.MemberApiType;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
 @ExtendWith(MockitoExtension.class)
@@ -73,8 +70,8 @@ public class FeedbackServiceTest {
 	@DisplayName("피드백 확인")
 	class UpdateFeedbackTest {
 		@Test
-		@DisplayName("피드백 내역이 존재하면 apiType이 mentees일 때 멘티 피드백을 추가한다.")
-		void when_feedbackExistsAndApiTypeIsMentees_expect_updateFeedbackByApiType() {
+		@DisplayName("피드백 내역이 존재하면 멘티 피드백을 추가한다.")
+		void when_feedbackExists_expect_updateFeedbackByMentee() {
 			Feedback feedback = Feedback.of(1L, null, null);
 
 			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
@@ -82,14 +79,25 @@ public class FeedbackServiceTest {
 			BDDMockito.willDoNothing()
 				.given(feedbackMapper).updateMenteeFeedbackByMenteeScheduleId(anyLong(), anyString());
 
-			feedbackService.updateFeedback(1L, "멘티 피드백", MemberApiType.MENTEES);
+			feedbackService.updateFeedbackByMentee(1L, "멘티 피드백");
 
 			BDDMockito.verify(feedbackMapper)
 				.updateMenteeFeedbackByMenteeScheduleId(1L, "멘티 피드백");
 		}
 
 		@Test
-		@DisplayName("피드백 내역이 존재하면 apiType이 coaches일 때 멘티 피드백을 추가한다.")
+		@DisplayName("피드백 내역이 존재하지 않으면 NotFoundFeedbackException을 반환한다.")
+		void when_feedbackDoesNotExistsForMentee_expect_throwsNotFoundFeedbackException() {
+			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
+				.willReturn(Optional.empty());
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+					feedbackService.updateFeedbackByMentee(1L, "멘티 피드백"))
+				.isInstanceOf(NotFoundFeedbackException.class);
+		}
+
+		@Test
+		@DisplayName("피드백 내역이 존재하면 apiType이 coaches일 때 코치 피드백을 추가한다.")
 		void when_feedbackExistsAndApiTypeIsCoaches_expect_updateFeedbackByApiType() {
 			Feedback feedback = Feedback.of(1L, null, null);
 
@@ -98,22 +106,21 @@ public class FeedbackServiceTest {
 			BDDMockito.willDoNothing()
 				.given(feedbackMapper).updateCoachFeedbackByMenteeScheduleId(anyLong(), anyString());
 
-			feedbackService.updateFeedback(1L, "코치 피드백", MemberApiType.COACHES);
+			feedbackService.updateFeedbackByCoach(1L, "코치 피드백");
 
 			BDDMockito.verify(feedbackMapper)
 				.updateCoachFeedbackByMenteeScheduleId(1L, "코치 피드백");
 		}
 
-		@ParameterizedTest
-		@ValueSource(strings = {"MENTEES", "COACHES"})
+		@Test
 		@DisplayName("피드백 내역이 존재하지 않으면 NotFoundFeedbackException을 반환한다.")
-		void when_feedbackDoesNotExists_expect_throwsNotFoundFeedbackException(String apiType) {
+		void when_feedbackDoesNotExistsForCoach_expect_throwsNotFoundFeedbackException() {
 			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
 				.willReturn(Optional.empty());
 
 			AssertionsForClassTypes.assertThatThrownBy(() ->
-				feedbackService.updateFeedback(1L, "피드백", MemberApiType.valueOf(apiType)))
-			.isInstanceOf(NotFoundFeedbackException.class);
+					feedbackService.updateFeedbackByCoach(1L, "코치 피드백"))
+				.isInstanceOf(NotFoundFeedbackException.class);
 		}
 	}
 }

--- a/src/test/java/cobook/buddywisdom/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/service/FeedbackServiceTest.java
@@ -1,0 +1,119 @@
+package cobook.buddywisdom.feedback.service;
+
+import static org.mockito.ArgumentMatchers.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import cobook.buddywisdom.feedback.domain.Feedback;
+import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
+import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
+import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
+import cobook.buddywisdom.global.vo.MemberApiType;
+import cobook.buddywisdom.util.WithMockCustomUser;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedbackServiceTest {
+
+	@Mock
+	FeedbackMapper feedbackMapper;
+
+	@InjectMocks
+	FeedbackService feedbackService;
+
+	@Nested
+	@WithMockCustomUser
+	@DisplayName("피드백 조회")
+	class FeedbackTest {
+		@Test
+		@DisplayName("해당하는 피드백이 존재하면 해당 정보를 반환한다.")
+		void when_feedbackExists_expect_returnResponse() {
+			long scheduleId = 1L;
+
+			Feedback feedback = Feedback.of(scheduleId, "코치 피드백", "멘티 피드백");
+
+			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
+				.willReturn(Optional.of(feedback));
+
+			Optional<FeedbackResponseDto> feedbackResponseDto =
+				feedbackService.getFeedback(scheduleId);
+
+			Assertions.assertNotNull(feedbackResponseDto);
+		}
+
+		@Test
+		@DisplayName("해당하는 피드백이 존재하지 않으면 빈 객체를 반환한다.")
+		void when_feedbackDoesNotExists_expect_returnOptionalEmpty() {
+			long scheduleId = 1L;
+
+			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
+				.willReturn(Optional.empty());
+
+			Optional<FeedbackResponseDto> expectedResponse =
+				feedbackService.getFeedback(scheduleId);
+
+			Assertions.assertTrue(expectedResponse.isEmpty());
+		}
+	}
+
+	@Nested
+	@WithMockCustomUser
+	@DisplayName("피드백 확인")
+	class UpdateFeedbackTest {
+		@Test
+		@DisplayName("피드백 내역이 존재하면 apiType이 mentees일 때 멘티 피드백을 추가한다.")
+		void when_feedbackExistsAndApiTypeIsMentees_expect_updateFeedbackByApiType() {
+			Feedback feedback = Feedback.of(1L, null, null);
+
+			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
+					.willReturn(Optional.of(feedback));
+			BDDMockito.willDoNothing()
+				.given(feedbackMapper).updateMenteeFeedbackByMenteeScheduleId(anyLong(), anyString());
+
+			feedbackService.updateFeedback(1L, "멘티 피드백", MemberApiType.MENTEES);
+
+			BDDMockito.verify(feedbackMapper)
+				.updateMenteeFeedbackByMenteeScheduleId(1L, "멘티 피드백");
+		}
+
+		@Test
+		@DisplayName("피드백 내역이 존재하면 apiType이 coaches일 때 멘티 피드백을 추가한다.")
+		void when_feedbackExistsAndApiTypeIsCoaches_expect_updateFeedbackByApiType() {
+			Feedback feedback = Feedback.of(1L, null, null);
+
+			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
+				.willReturn(Optional.of(feedback));
+			BDDMockito.willDoNothing()
+				.given(feedbackMapper).updateCoachFeedbackByMenteeScheduleId(anyLong(), anyString());
+
+			feedbackService.updateFeedback(1L, "코치 피드백", MemberApiType.COACHES);
+
+			BDDMockito.verify(feedbackMapper)
+				.updateCoachFeedbackByMenteeScheduleId(1L, "코치 피드백");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"MENTEES", "COACHES"})
+		@DisplayName("피드백 내역이 존재하지 않으면 NotFoundFeedbackException을 반환한다.")
+		void when_feedbackDoesNotExists_expect_throwsNotFoundFeedbackException(String apiType) {
+			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
+				.willReturn(Optional.empty());
+
+			AssertionsForClassTypes.assertThatThrownBy(() ->
+				feedbackService.updateFeedback(1L, "피드백", MemberApiType.valueOf(apiType)))
+			.isInstanceOf(NotFoundFeedbackException.class);
+		}
+	}
+}


### PR DESCRIPTION
### 작업 내용
- `MemberApiType`으로 멘티와 코치가 공통 로직을 사용할 수 있도록 한다.
- Converter를 활용하여 String 형태로 받은 Path variable을 Enum 타입으로 변환한다.
- 코치와 멘티가 각각의 피드백을 등록한다.