### PR TITLE
[#30] 피드백 변경 사항을 피드 메시지로 저장한다.

### DIFF
--- a/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
+++ b/src/main/java/cobook/buddywisdom/feedback/controller/FeedbackController.java
@@ -1,8 +1,11 @@
 package cobook.buddywisdom.feedback.controller;
 
+import static cobook.buddywisdom.global.vo.MemberApiType.*;
+
 import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.dto.UpdateFeedbackRequestDto;
 import cobook.buddywisdom.feedback.service.FeedbackService;
+import cobook.buddywisdom.global.security.CustomUserDetails;
 import cobook.buddywisdom.global.vo.MemberApiType;
 import jakarta.validation.Valid;
 
@@ -33,12 +37,13 @@ public class FeedbackController {
 	}
 
 	@PatchMapping("/{memberApiType}/feedback")
-	public ResponseEntity<Void> updateFeedback(@PathVariable final MemberApiType memberApiType,
+	public ResponseEntity<Void> updateFeedback(@AuthenticationPrincipal CustomUserDetails member,
+												@PathVariable final MemberApiType memberApiType,
 												@RequestBody @Valid final UpdateFeedbackRequestDto request) {
-		if (MemberApiType.COACHES.equals(memberApiType)) {
-			feedbackService.updateFeedbackByCoach(request.menteeScheduleId(), request.feedback());
-		} else if (MemberApiType.MENTEES.equals(memberApiType)) {
-			feedbackService.updateFeedbackByMentee(request.menteeScheduleId(), request.feedback());
+		if (COACHES.equals(memberApiType)) {
+			feedbackService.updateFeedbackByCoach(member.getId(), request.menteeScheduleId(), request.feedback());
+		} else if (MENTEES.equals(memberApiType)) {
+			feedbackService.updateFeedbackByMentee(member.getId(), request.menteeScheduleId(), request.feedback());
 		}
 
 		return ResponseEntity.noContent().build();

--- a/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
+++ b/src/main/java/cobook/buddywisdom/feedback/service/FeedbackService.java
@@ -1,40 +1,69 @@
 package cobook.buddywisdom.feedback.service;
 
+import static cobook.buddywisdom.global.vo.MessageTemplate.*;
+
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+import cobook.buddywisdom.coach.service.CoachScheduleService;
 import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
 import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
 import cobook.buddywisdom.global.exception.ErrorMessage;
+import cobook.buddywisdom.global.util.MessageUtil;
+import cobook.buddywisdom.mentee.domain.MenteeSchedule;
+import cobook.buddywisdom.mentee.service.MenteeScheduleService;
+import cobook.buddywisdom.messaging.producer.FeedMessageProducer;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class FeedbackService {
 
 	private final FeedbackMapper feedbackMapper;
+	private final MenteeScheduleService menteeScheduleService;
+	private final CoachScheduleService coachScheduleService;
+	private final FeedMessageProducer feedMessageProducer;
+	private final MessageUtil messageUtil;
 
-	public FeedbackService(FeedbackMapper feedbackMapper) {
-		this.feedbackMapper = feedbackMapper;
-	}
-
+	@Transactional(readOnly = true)
 	public Optional<FeedbackResponseDto> getFeedback(long menteeScheduleId) {
 		return feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
 			.map(FeedbackResponseDto::from);
 	}
 
-	public void updateFeedbackByCoach(long menteeScheduleId, String feedback) {
-		feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
-			.orElseThrow(() -> new NotFoundFeedbackException(ErrorMessage.NOT_FOUND_FEEDBACK));
-
+	public void updateFeedbackByCoach(long coachId, long menteeScheduleId, String feedback) {
+		checkIfFeedbackExists(menteeScheduleId);
 		feedbackMapper.updateCoachFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
+
+		MenteeSchedule menteeSchedule = menteeScheduleService.getMenteeScheduleByScheduleId(menteeScheduleId);
+		CoachSchedule coachSchedule = coachScheduleService.getCoachSchedule(menteeScheduleId, true);
+		processEventProducer(coachId, menteeSchedule.getMenteeId(), coachSchedule.getPossibleDateTime());
 	}
 
-	public void updateFeedbackByMentee(long menteeScheduleId, String feedback) {
-		feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
-			.orElseThrow(() -> new NotFoundFeedbackException(ErrorMessage.NOT_FOUND_FEEDBACK));
-
+	public void updateFeedbackByMentee(long menteeId, long menteeScheduleId, String feedback) {
+		checkIfFeedbackExists(menteeScheduleId);
 		feedbackMapper.updateMenteeFeedbackByMenteeScheduleId(menteeScheduleId, feedback);
 
+		CoachSchedule coachSchedule = coachScheduleService.getCoachSchedule(menteeScheduleId, true);
+		processEventProducer(menteeId, coachSchedule.getCoachId(), coachSchedule.getPossibleDateTime());
+	}
+
+	private void processEventProducer(long senderId, long receiverId, LocalDateTime localDateTime) {
+		String dateTime = messageUtil.convertToString(localDateTime);
+
+		feedMessageProducer.produceScheduleEvent(senderId, receiverId, () ->
+			MessageFormat.format(UPDATE_FEEDBACK, dateTime));
+	}
+
+	private void checkIfFeedbackExists(long menteeScheduleId) {
+		feedbackMapper.findByMenteeScheduleId(menteeScheduleId)
+			.orElseThrow(() -> new NotFoundFeedbackException(ErrorMessage.NOT_FOUND_FEEDBACK));
 	}
 }

--- a/src/main/java/cobook/buddywisdom/global/vo/MessageTemplate.java
+++ b/src/main/java/cobook/buddywisdom/global/vo/MessageTemplate.java
@@ -12,4 +12,5 @@ public class MessageTemplate {
 	public static final String REQUEST_CANCEL_SCHEDULE = "%s님이 {0} 코칭 일정 취소 요청을 보냈습니다.";
 	public static final String CONFIRM_CANCEL_SCHEDULE = "%s님이 {0} 코칭 일정 취소 요청을 확인했습니다.";
 	public static final String UPDATE_SCHEDULE = "%s님이 {0}에서 {1}로 코칭 일정을 변경했습니다.";
+	public static final String UPDATE_FEEDBACK = "%s님이 {0} 코칭에 대한 피드백을 작성했습니다.";
 }

--- a/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
+++ b/src/main/java/cobook/buddywisdom/mentee/service/MenteeScheduleService.java
@@ -65,6 +65,11 @@ public class MenteeScheduleService {
 			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
 	}
 
+	public MenteeSchedule getMenteeScheduleByScheduleId(long coachingScheduleId) {
+		return menteeScheduleMapper.findByCoachingScheduleId(coachingScheduleId)
+			.orElseThrow(() -> new NotFoundMenteeScheduleException(ErrorMessage.NOT_FOUND_MENTEE_SCHEDULE));
+	}
+
 	public List<MyCoachScheduleResponseDto> getMyCoachSchedule(long menteeId) {
 		CoachingRelationship coachingRelationship = coachingRelationshipService.getCoachingRelationshipByMenteeId(menteeId);
 

--- a/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/controller/FeedbackControllerTest.java
@@ -2,6 +2,11 @@ package cobook.buddywisdom.feedback.controller;
 
 import static cobook.buddywisdom.global.vo.MemberApiType.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Optional;
 
@@ -59,16 +64,14 @@ public class FeedbackControllerTest {
 			Feedback feedback = Feedback.of(scheduleId, "코치 피드백", "멘티 피드백");
 			FeedbackResponseDto feedbackResponseDto = FeedbackResponseDto.from(feedback);
 
-			BDDMockito.given(feedbackService.getFeedback(anyLong()))
-				.willReturn(Optional.of(feedbackResponseDto));
+			given(feedbackService.getFeedback(anyLong())).willReturn(Optional.of(feedbackResponseDto));
 
 			ResultActions response =
-				mockMvc.perform(
-					MockMvcRequestBuilders.get(BASE_URL + memberApiType + "/feedback/" + scheduleId))
-				.andDo(MockMvcResultHandlers.print());
+				mockMvc.perform(get(BASE_URL + memberApiType + "/feedback/" + scheduleId))
+				.andDo(print());
 
-			BDDMockito.verify(feedbackService).getFeedback(anyLong());
-			response.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(feedbackService).getFeedback(anyLong());
+			response.andExpect(status().isOk());
 		}
 	}
 
@@ -81,19 +84,18 @@ public class FeedbackControllerTest {
 		void when_menteeRequestInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
 			UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "멘티 피드백");
 
-			BDDMockito.willDoNothing()
-				.given(feedbackService).updateFeedbackByMentee(anyLong(), anyString());
+			willDoNothing()
+				.given(feedbackService).updateFeedbackByMentee(anyLong(), anyLong(), anyString());
 
 			ResultActions response =
-				mockMvc.perform(
-					MockMvcRequestBuilders.patch(BASE_URL + MENTEES + "/feedback")
+				mockMvc.perform(patch(BASE_URL + MENTEES + "/feedback")
 						.with(SecurityMockMvcRequestPostProcessors.csrf())
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(request)))
-				.andDo(MockMvcResultHandlers.print());
+				.andDo(print());
 
-			BDDMockito.verify(feedbackService).updateFeedbackByMentee(anyLong(), anyString());
-			response.andExpect(MockMvcResultMatchers.status().isNoContent());
+			verify(feedbackService).updateFeedbackByMentee(anyLong(), anyLong(), anyString());
+			response.andExpect(status().isNoContent());
 		}
 
 		@Test
@@ -101,19 +103,18 @@ public class FeedbackControllerTest {
 		void when_coachRequestInformationIsValid_expect_callMethodAndReturn200Ok() throws Exception {
 			UpdateFeedbackRequestDto request = new UpdateFeedbackRequestDto(1L, "코치 피드백");
 
-			BDDMockito.willDoNothing()
-				.given(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
+			willDoNothing()
+				.given(feedbackService).updateFeedbackByCoach(anyLong(), anyLong(), anyString());
 
 			ResultActions response =
-				mockMvc.perform(
-						MockMvcRequestBuilders.patch(BASE_URL + COACHES + "/feedback")
+				mockMvc.perform(patch(BASE_URL + COACHES + "/feedback")
 							.with(SecurityMockMvcRequestPostProcessors.csrf())
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(request)))
-					.andDo(MockMvcResultHandlers.print());
+					.andDo(print());
 
-			BDDMockito.verify(feedbackService).updateFeedbackByCoach(anyLong(), anyString());
-			response.andExpect(MockMvcResultMatchers.status().isNoContent());
+			verify(feedbackService).updateFeedbackByCoach(anyLong(), anyLong(), anyString());
+			response.andExpect(status().isNoContent());
 		}
 	}
 }

--- a/src/test/java/cobook/buddywisdom/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/feedback/service/FeedbackServiceTest.java
@@ -1,24 +1,31 @@
 package cobook.buddywisdom.feedback.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
-import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import cobook.buddywisdom.coach.domain.CoachSchedule;
+import cobook.buddywisdom.coach.service.CoachScheduleService;
 import cobook.buddywisdom.feedback.domain.Feedback;
 import cobook.buddywisdom.feedback.dto.FeedbackResponseDto;
 import cobook.buddywisdom.feedback.exception.NotFoundFeedbackException;
 import cobook.buddywisdom.feedback.mapper.FeedbackMapper;
+import cobook.buddywisdom.global.util.MessageUtil;
+import cobook.buddywisdom.mentee.domain.MenteeSchedule;
+import cobook.buddywisdom.mentee.service.MenteeScheduleService;
+import cobook.buddywisdom.messaging.producer.FeedMessageProducer;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +33,18 @@ public class FeedbackServiceTest {
 
 	@Mock
 	FeedbackMapper feedbackMapper;
+
+	@Mock
+	MenteeScheduleService menteeScheduleService;
+
+	@Mock
+	CoachScheduleService coachScheduleService;
+
+	@Mock
+	FeedMessageProducer feedMessageProducer;
+
+	@Mock
+	MessageUtil messageUtil;
 
 	@InjectMocks
 	FeedbackService feedbackService;
@@ -38,16 +57,13 @@ public class FeedbackServiceTest {
 		@DisplayName("해당하는 피드백이 존재하면 해당 정보를 반환한다.")
 		void when_feedbackExists_expect_returnResponse() {
 			long scheduleId = 1L;
-
 			Feedback feedback = Feedback.of(scheduleId, "코치 피드백", "멘티 피드백");
 
-			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
-				.willReturn(Optional.of(feedback));
+			given(feedbackMapper.findByMenteeScheduleId(anyLong())).willReturn(Optional.of(feedback));
 
-			Optional<FeedbackResponseDto> feedbackResponseDto =
-				feedbackService.getFeedback(scheduleId);
+			Optional<FeedbackResponseDto> feedbackResponseDto = feedbackService.getFeedback(scheduleId);
 
-			Assertions.assertNotNull(feedbackResponseDto);
+			assertNotNull(feedbackResponseDto);
 		}
 
 		@Test
@@ -55,13 +71,11 @@ public class FeedbackServiceTest {
 		void when_feedbackDoesNotExists_expect_returnOptionalEmpty() {
 			long scheduleId = 1L;
 
-			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
-				.willReturn(Optional.empty());
+			given(feedbackMapper.findByMenteeScheduleId(anyLong())).willReturn(Optional.empty());
 
-			Optional<FeedbackResponseDto> expectedResponse =
-				feedbackService.getFeedback(scheduleId);
+			Optional<FeedbackResponseDto> expectedResponse = feedbackService.getFeedback(scheduleId);
 
-			Assertions.assertTrue(expectedResponse.isEmpty());
+			assertTrue(expectedResponse.isEmpty());
 		}
 	}
 
@@ -73,26 +87,26 @@ public class FeedbackServiceTest {
 		@DisplayName("피드백 내역이 존재하면 멘티 피드백을 추가한다.")
 		void when_feedbackExists_expect_updateFeedbackByMentee() {
 			Feedback feedback = Feedback.of(1L, null, null);
+			CoachSchedule coachSchedule = CoachSchedule.of(1L, 3L, LocalDateTime.now(), true);
 
-			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
-					.willReturn(Optional.of(feedback));
-			BDDMockito.willDoNothing()
+			given(feedbackMapper.findByMenteeScheduleId(anyLong())).willReturn(Optional.of(feedback));
+			willDoNothing()
 				.given(feedbackMapper).updateMenteeFeedbackByMenteeScheduleId(anyLong(), anyString());
+			given(coachScheduleService.getCoachSchedule(anyLong(), anyBoolean())).willReturn(coachSchedule);
 
-			feedbackService.updateFeedbackByMentee(1L, "멘티 피드백");
+			feedbackService.updateFeedbackByMentee(4L, 1L, "멘티 피드백");
 
-			BDDMockito.verify(feedbackMapper)
+			verify(feedbackMapper)
 				.updateMenteeFeedbackByMenteeScheduleId(1L, "멘티 피드백");
 		}
 
 		@Test
 		@DisplayName("피드백 내역이 존재하지 않으면 NotFoundFeedbackException을 반환한다.")
 		void when_feedbackDoesNotExistsForMentee_expect_throwsNotFoundFeedbackException() {
-			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
-				.willReturn(Optional.empty());
+			given(feedbackMapper.findByMenteeScheduleId(anyLong())).willReturn(Optional.empty());
 
-			AssertionsForClassTypes.assertThatThrownBy(() ->
-					feedbackService.updateFeedbackByMentee(1L, "멘티 피드백"))
+			assertThatThrownBy(() ->
+					feedbackService.updateFeedbackByMentee(4L, 1L, "멘티 피드백"))
 				.isInstanceOf(NotFoundFeedbackException.class);
 		}
 
@@ -100,26 +114,28 @@ public class FeedbackServiceTest {
 		@DisplayName("피드백 내역이 존재하면 apiType이 coaches일 때 코치 피드백을 추가한다.")
 		void when_feedbackExistsAndApiTypeIsCoaches_expect_updateFeedbackByApiType() {
 			Feedback feedback = Feedback.of(1L, null, null);
+			MenteeSchedule menteeSchedule = MenteeSchedule.of(1L, 4L);
+			CoachSchedule coachSchedule = CoachSchedule.of(1L, 3L, LocalDateTime.now(), true);
 
-			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
-				.willReturn(Optional.of(feedback));
-			BDDMockito.willDoNothing()
+			given(feedbackMapper.findByMenteeScheduleId(anyLong())).willReturn(Optional.of(feedback));
+			willDoNothing()
 				.given(feedbackMapper).updateCoachFeedbackByMenteeScheduleId(anyLong(), anyString());
+			given(menteeScheduleService.getMenteeScheduleByScheduleId(anyLong())).willReturn(menteeSchedule);
+			given(coachScheduleService.getCoachSchedule(anyLong(), anyBoolean())).willReturn(coachSchedule);
 
-			feedbackService.updateFeedbackByCoach(1L, "코치 피드백");
+			feedbackService.updateFeedbackByCoach(3L, 1L, "코치 피드백");
 
-			BDDMockito.verify(feedbackMapper)
+			verify(feedbackMapper)
 				.updateCoachFeedbackByMenteeScheduleId(1L, "코치 피드백");
 		}
 
 		@Test
 		@DisplayName("피드백 내역이 존재하지 않으면 NotFoundFeedbackException을 반환한다.")
 		void when_feedbackDoesNotExistsForCoach_expect_throwsNotFoundFeedbackException() {
-			BDDMockito.given(feedbackMapper.findByMenteeScheduleId(anyLong()))
-				.willReturn(Optional.empty());
+			given(feedbackMapper.findByMenteeScheduleId(anyLong())).willReturn(Optional.empty());
 
-			AssertionsForClassTypes.assertThatThrownBy(() ->
-					feedbackService.updateFeedbackByCoach(1L, "코치 피드백"))
+			assertThatThrownBy(() ->
+					feedbackService.updateFeedbackByCoach(3L, 1L, "코치 피드백"))
 				.isInstanceOf(NotFoundFeedbackException.class);
 		}
 	}


### PR DESCRIPTION
### 작업 내용
- 피드백이 업데이트 됐을 때 관련 정보를 피드 메시지로 저장한다.
- 테스트 코드에 이를 적용하고 import static문을 활용해 가독성을 높인다.