### PR TITLE
[#37] 멘티 일정 취소 기능 관련 코드를 리팩토링한다.

### DIFF
--- a/src/test/java/cobook/buddywisdom/cancellation/controller/CancelRequestControllerTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/controller/CancelRequestControllerTest.java
@@ -1,6 +1,12 @@
 package cobook.buddywisdom.cancellation.controller;
 
+import static cobook.buddywisdom.cancellation.vo.DirectionType.*;
+import static cobook.buddywisdom.global.vo.MemberApiType.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,7 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.mockito.BDDMockito;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,9 +26,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -30,12 +33,11 @@ import cobook.buddywisdom.cancellation.dto.request.CancelRequestDto;
 import cobook.buddywisdom.cancellation.dto.request.ConfirmCancelRequestDto;
 import cobook.buddywisdom.cancellation.dto.response.CancelRequestResponseDto;
 import cobook.buddywisdom.cancellation.service.CancelRequestService;
-import cobook.buddywisdom.cancellation.vo.DirectionType;
 import cobook.buddywisdom.util.WithMockCustomUser;
 
 @AutoConfigureMybatis
-@WebMvcTest(MenteeCancelRequestController.class)
-public class MenteeCancelRequestControllerTest {
+@WebMvcTest(CancelRequestController.class)
+public class CancelRequestControllerTest {
 
 	@MockBean
 	private CancelRequestService cancelRequestService;
@@ -46,7 +48,7 @@ public class MenteeCancelRequestControllerTest {
 	@Autowired
 	private ObjectMapper objectMapper;
 
-	private final static String BASE_URL = "/api/v1/mentees/schedule";
+	private final static String BASE_URL = "/api/v1/";
 
 	private static CancelRequestResponseDto cancelRequestResponseDto;
 
@@ -59,48 +61,44 @@ public class MenteeCancelRequestControllerTest {
 
 	@Nested
 	@DisplayName("코칭 취소 요청 내역 조회")
-	@WithMockCustomUser(role = "MENTEE")
+	@WithMockCustomUser()
 	class CancelRequestTest {
-		@Test
-		@DisplayName("인증된 멘티의 보낸 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
-		void when_authenticatedMenteeExistsAndDirectionTypeIsSent_expect_callMethodAndReturn200Ok() throws Exception {
-			BDDMockito
-				.given(cancelRequestService.getCancelRequest(anyLong(), eq(DirectionType.SENT)))
+		@ParameterizedTest
+		@ValueSource(strings = {"mentees", "coaches"})
+		@DisplayName("인증된 회원의 보낸 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
+		void when_authenticatedMenteeExistsAndDirectionTypeIsSent_expect_callMethodAndReturn200Ok(String type) throws Exception {
+			given(cancelRequestService.getCancelRequest(anyLong(), eq(SENT)))
 				.willReturn(List.of(cancelRequestResponseDto));
 
 			ResultActions response =
-				mockMvc.perform(
-					MockMvcRequestBuilders.get(BASE_URL + "/cancel-request")
-						.param("direction", String.valueOf(DirectionType.SENT)))
-				.andDo(MockMvcResultHandlers.print());
+				mockMvc.perform(get(BASE_URL + type + "/cancel-request")
+						.param("direction", String.valueOf(SENT)))
+				.andDo(print());
 
-			BDDMockito.verify(cancelRequestService)
-				.getCancelRequest(anyLong(), eq(DirectionType.SENT));
-			response.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(cancelRequestService).getCancelRequest(anyLong(), eq(SENT));
+			response.andExpect(status().isOk());
 
 		}
 
-		@Test
-		@DisplayName("인증된 멘티의 받은 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
-		void when_authenticatedMenteeExistsAndDirectionTypeIsReceived_expect_callMethodAndReturn200Ok() throws Exception {
-			BDDMockito
-				.given(cancelRequestService.getCancelRequest(anyLong(), eq(DirectionType.RECEIVED)))
+		@ParameterizedTest
+		@ValueSource(strings = {"mentees", "coaches"})
+		@DisplayName("인증된 회원의 받은 취소 내역을 조회하기 위해 메서드를 호출하고 200 OK를 반환한다.")
+		void when_authenticatedMenteeExistsAndDirectionTypeIsReceived_expect_callMethodAndReturn200Ok(String type) throws Exception {
+			given(cancelRequestService.getCancelRequest(anyLong(), eq(RECEIVED)))
 				.willReturn(List.of(cancelRequestResponseDto));
 
 			ResultActions response =
-				mockMvc.perform(
-						MockMvcRequestBuilders.get(BASE_URL + "/cancel-request")
-							.param("direction", String.valueOf(DirectionType.RECEIVED)))
-					.andDo(MockMvcResultHandlers.print());
+				mockMvc.perform(get(BASE_URL + type + "/cancel-request")
+							.param("direction", String.valueOf(RECEIVED)))
+					.andDo(print());
 
-			BDDMockito.verify(cancelRequestService)
-				.getCancelRequest(anyLong(), eq(DirectionType.RECEIVED));
-			response.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(cancelRequestService).getCancelRequest(anyLong(), eq(RECEIVED));
+			response.andExpect(status().isOk());
 		}
 	}
 
 	@Nested
-	@DisplayName("코칭 취소 요청")
+	@DisplayName("멘티 코칭 취소 요청")
 	@WithMockCustomUser(role = "MENTEE")
 	class CreateCancelRequestTest {
 		@Test
@@ -108,21 +106,19 @@ public class MenteeCancelRequestControllerTest {
 		void when_scheduleIdAndReasonOfCancelAreValid_expects_callMethodAndReturn200Ok() throws Exception {
 			CancelRequestDto cancelRequestDto = new CancelRequestDto(1L, "취소 사유");
 
-			BDDMockito
-				.given(cancelRequestService.saveCancelRequestByMentee(anyLong(), anyLong(), anyString()))
+			given(cancelRequestService.saveCancelRequestByMentee(anyLong(), anyLong(), anyString()))
 				.willReturn(cancelRequestResponseDto);
 
 			ResultActions response =
-				mockMvc.perform(
-					MockMvcRequestBuilders.post(BASE_URL + "/cancel-request")
+				mockMvc.perform(post(BASE_URL + MENTEES + "/cancel-request")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(cancelRequestDto))
 						.with(SecurityMockMvcRequestPostProcessors.csrf()))
-					.andDo(MockMvcResultHandlers.print());
+					.andDo(print());
 
-			BDDMockito.verify(cancelRequestService)
+			verify(cancelRequestService)
 				.saveCancelRequestByMentee(anyLong(), anyLong(), anyString());
-			response.andExpect(MockMvcResultMatchers.status().isOk());
+			response.andExpect(status().isOk());
 		}
 
 		@ParameterizedTest
@@ -132,41 +128,41 @@ public class MenteeCancelRequestControllerTest {
 			CancelRequestDto cancelRequestDto = new CancelRequestDto(null, reason);
 
 			ResultActions response =
-				mockMvc.perform(
-						MockMvcRequestBuilders.post(BASE_URL + "/cancel-request")
+				mockMvc.perform(post(BASE_URL + MENTEES + "/cancel-request")
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(cancelRequestDto))
 							.with(SecurityMockMvcRequestPostProcessors.csrf()))
-					.andDo(MockMvcResultHandlers.print());
+					.andDo(print());
 
-			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+			response.andExpect(status().isBadRequest());
 		}
 	}
 
 	@Nested
-	@DisplayName("코칭 취소 요청 확인")
+	@DisplayName("멘티 코칭 취소 요청 확인")
 	@WithMockCustomUser(role = "MENTEE")
 	class UpdateCancelRequestTest {
 		@Test
-		@DisplayName("유효한 취소 요청 및 일정 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
-		void when_requestIdsArdValid_expects_callMethodAndReturns200Ok() throws Exception {
+		@DisplayName("회원의 유효한 취소 요청 및 일정 정보가 전달되면 메서드를 호출하고 200 OK를 반환한다.")
+		void when_requestIdsArdValidForMentee_expects_callMethodAndReturns200Ok() throws Exception {
 			ConfirmCancelRequestDto confirmCancelRequestDto =
 				new ConfirmCancelRequestDto(1L, 1L);
 
-			BDDMockito.willDoNothing()
-				.given(cancelRequestService).confirmCancelRequest(anyLong(), anyLong(), anyLong());
+			willDoNothing()
+				.given(cancelRequestService).confirmCancelRequestByMentee(anyLong(), anyLong(), anyLong());
+			willDoNothing()
+				.given(cancelRequestService).confirmCancelRequest(anyLong(), anyLong());
 
 			ResultActions response =
-				mockMvc.perform(
-						MockMvcRequestBuilders.patch(BASE_URL + "/cancel-request")
+				mockMvc.perform(patch(BASE_URL + MENTEES + "/cancel-request")
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(confirmCancelRequestDto))
 							.with(SecurityMockMvcRequestPostProcessors.csrf()))
-					.andDo(MockMvcResultHandlers.print());
+					.andDo(print());
 
-			BDDMockito.verify(cancelRequestService)
-				.confirmCancelRequest(anyLong(), anyLong(), anyLong());
-			response.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(cancelRequestService)
+				.confirmCancelRequestByMentee(anyLong(), anyLong(), anyLong());
+			response.andExpect(status().isOk());
 		}
 
 		@Test
@@ -176,14 +172,13 @@ public class MenteeCancelRequestControllerTest {
 				new ConfirmCancelRequestDto(null, null);
 
 			ResultActions response =
-				mockMvc.perform(
-						MockMvcRequestBuilders.patch(BASE_URL + "/cancel-request")
+				mockMvc.perform(patch(BASE_URL + MENTEES + "/cancel-request")
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(confirmCancelRequestDto))
 							.with(SecurityMockMvcRequestPostProcessors.csrf()))
-					.andDo(MockMvcResultHandlers.print());
+					.andDo(print());
 
-			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+			response.andExpect(status().isBadRequest());
 		}
 	}
 }

--- a/src/test/java/cobook/buddywisdom/cancellation/service/CancelRequestServiceTest.java
+++ b/src/test/java/cobook/buddywisdom/cancellation/service/CancelRequestServiceTest.java
@@ -133,7 +133,7 @@ public class CancelRequestServiceTest {
 	}
 
 	@Nested
-	@DisplayName("코칭 취소 요청")
+	@DisplayName("멘티 코칭 취소 요청")
 	class CreateCancelRequestTest {
 		@Test
 		@DisplayName("유효한 정보가 전달되면 요청이 완료되고 취소 요청 정보를 반환한다.")
@@ -183,7 +183,7 @@ public class CancelRequestServiceTest {
 	}
 
 	@Nested
-	@DisplayName("코칭 취소 요청 확인")
+	@DisplayName("멘티 코칭 취소 요청 확인")
 	class UpdateCancelRequestTest {
 		@Test
 		@DisplayName("취소 요청 및 일정 정보가 전달되면 상태 값을 변경하고 해당 스케줄을 삭제한다.")
@@ -197,7 +197,7 @@ public class CancelRequestServiceTest {
 			given(coachScheduleService.getCoachSchedule(anyLong(), anyBoolean()))
 				.willReturn(coachSchedule);
 
-			cancelRequestService.confirmCancelRequest(1L, 1L, 1L);
+			cancelRequestService.confirmCancelRequestByMentee(1L, 1L, 1L);
 
 			verify(cancelRequestMapper).findById(1L);
 			verify(cancelRequestMapper).updateConfirmYn(1L, true);
@@ -211,7 +211,7 @@ public class CancelRequestServiceTest {
 				.willReturn(Optional.empty());
 
 			assertThatThrownBy(() ->
-					cancelRequestService.confirmCancelRequest(1L, 1L, 1L))
+					cancelRequestService.confirmCancelRequestByMentee(1L, 1L, 1L))
 				.isInstanceOf(NotFoundCancelRequestException.class);
 		}
 
@@ -225,7 +225,7 @@ public class CancelRequestServiceTest {
 				.willReturn(Optional.of(confirmedRequest));
 
 			assertThatThrownBy(() ->
-					cancelRequestService.confirmCancelRequest(1L, 1L, 1L))
+					cancelRequestService.confirmCancelRequestByMentee(1L, 1L, 1L))
 				.isInstanceOf(ConfirmedCancelRequestException.class);
 		}
 	}


### PR DESCRIPTION
### 작업 내용
- MemberApiType을 활용해 공통화할 수 있는 작업을 리팩토링한다.
- 테스트 코드에 이를 반영하고 static import를 활용하여 가독성을 높인다.