### PR TITLE
[#67] TAG 값을 가져오지 못하는 문제를 해결한다.

### DIFF
--- a/.github/workflows/budsdom-cd.yml
+++ b/.github/workflows/budsdom-cd.yml
@@ -38,7 +38,8 @@ jobs:
           key: ${{ secrets.SERVER_PRIVATE_KEY }}
           port: ${{ secrets.SERVER_PORT }}
           script: |
-            echo TAG=${{ env.DOCKER_TAG }} >> .env
+            DOCKER_TAG=$(docker images ${{ secrets.DOCKER_USERNAME}}/${{ secrets.DOCKER_HUB_REPO }} --format "{{.Tag}} {{.CreatedSince}}" | sort -k2 -r | head -n 1 | awk '{print $1}')
+            echo TAG=${DOCKER_TAG} >> .env
             echo USERNAME=${{ secrets.DOCKER_USERNAME }} >> .env
             echo REPOSITORY=${{ secrets.DOCKER_HUB_REPO }} >> .env
 

--- a/.github/workflows/budsdom-ci.yml
+++ b/.github/workflows/budsdom-ci.yml
@@ -36,4 +36,3 @@ jobs:
           docker build --platform linux/amd64 --build-arg DEPENDENCY=build/dependency -t ${{ secrets.DOCKER_HUB_REPO }} .
           docker tag ${{ secrets.DOCKER_HUB_REPO }} ${{ secrets.DOCKER_USERNAME}}/${{ secrets.DOCKER_HUB_REPO }}:${GITHUB_SHA::7}
           docker push ${{ secrets.DOCKER_USERNAME}}/${{ secrets.DOCKER_HUB_REPO }}:${GITHUB_SHA::7}
-          echo "DOCKER_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV


### PR DESCRIPTION
### 작업 내용
- 기존 `$GITHUB_ENV` 저장 스크립트 제거
- 직접 최신 이미지 태그 값 검색 후 환경 변수 파일에 저장